### PR TITLE
Smaller `regular-table.js` Asset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: trusty
 language: node_js
-node_js: "12"
+node_js: "10"
+
+before_install:
+  - npm install -g yarn
 
 install:
   - yarn

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,15 +4,10 @@ module.exports = {
             "@babel/preset-env",
             {
                 targets: {
-                    chrome: "70",
-                    node: "12",
-                    ios: "13",
                     esmodules: true,
                 },
-                useBuiltIns: "usage",
-                corejs: 3
-            }
-        ]
+            },
+        ],
     ],
     plugins: [
         "lodash",
@@ -20,6 +15,6 @@ module.exports = {
         "transform-custom-element-classes",
         "@babel/plugin-proposal-class-properties",
         "@babel/plugin-proposal-optional-chaining",
-        "./babel-plugin-transform-tagged-literal.js"
-    ]
+        "./babel-plugin-transform-tagged-literal.js",
+    ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/jpmorganchase/regular-table"
     },
     "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.18.1"
     },
     "license": "Apache-2.0",
     "main": "dist/esm/regular-table.js",
@@ -47,11 +47,11 @@
     },
     "devDependencies": {
         "@babel/cli": "^7.8.4",
-        "@babel/core": "^7.8.4",
+        "@babel/core": "^7.9.0",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/plugin-proposal-decorators": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-        "@babel/preset-env": "^7.8.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.1.0",
         "babel-plugin-lodash": "^3.3.4",
@@ -69,8 +69,9 @@
         "npm-run-all": "^4.1.3",
         "prettier": "^2.0.5",
         "puppeteer": "^3.1.0",
+        "source-map-explorer": "^2.4.2",
         "source-map-loader": "^0.2.4",
-        "webpack": "^4.31.0",
-        "webpack-cli": "^3.3.7"
+        "webpack": "^4.43.0",
+        "webpack-cli": "^3.3.11"
     }
 }

--- a/src/config/umd.config.js
+++ b/src/config/umd.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
     entry: "./dist/js/index.js",
-    mode: "development",
+    mode: "production",
     devtool: "source-map",
     module: {
         rules: [

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -8,10 +8,9 @@
  *
  */
 
-import isEqual from "lodash/isEqual";
 import {METADATA_MAP} from "./constants";
 import {RegularVirtualTableViewModel} from "./scroll_panel";
-import {getCellConfig, throttlePromise} from "./utils";
+import {getCellConfig, throttlePromise, isEqual} from "./utils";
 
 /**
  *

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -8,11 +8,10 @@
  *
  */
 
-import isEqual from "lodash/isEqual";
 import CONTAINER_STYLE from "../less/container.less";
 import MATERIAL_STYLE from "../less/material.less";
 
-import {log_perf, html, throttlePromise} from "./utils";
+import {log_perf, html, isEqual, throttlePromise} from "./utils";
 import {DEBUG, BROWSER_MAX_HEIGHT, DOUBLE_BUFFER_RECREATE, DOUBLE_BUFFER_ROW, DOUBLE_BUFFER_COLUMN} from "./constants";
 
 /**

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -8,7 +8,7 @@
  *
  */
 
-import isEqual from "lodash/isEqual";
+import {isEqual} from "./utils";
 import {ViewModel} from "./view_model";
 
 /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -129,6 +129,38 @@ const invertPromise = () => {
     return promise;
 };
 
+export function isEqual(a, b) {
+    if (a === b) return true;
+    if (a && b && typeof a == "object" && typeof b == "object") {
+        if (a.constructor !== b.constructor) return false;
+        let length, i, keys;
+        if (Array.isArray(a)) {
+            length = a.length;
+            if (length != b.length) return false;
+            for (i = length; i-- !== 0; ) if (!isEqual(a[i], b[i])) return false;
+            return true;
+        }
+
+        if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+        if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+        keys = Object.keys(a);
+        length = keys.length;
+        if (length !== Object.keys(b).length) return false;
+        for (i = length; i-- !== 0; ) {
+            if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+        }
+
+        for (i = length; i-- !== 0; ) {
+            let key = keys[i];
+            if (!isEqual(a[key], b[key])) return false;
+        }
+
+        return true;
+    }
+
+    return a !== a && b !== b;
+}
+
 export function throttlePromise(target, property, descriptor) {
     const lock = Symbol("private lock");
     const f = descriptor.value;


### PR DESCRIPTION
This PR remove lodash and core-js builtins, wihch simplifies the build and cuts ~15k of javascript from the UMD build.  Also fixes annoyingly dense travis warnings due to deprecated `yarn`.