### PR TITLE
Adding a file_browser.html example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Spreadsheets, Pivot Tables, File Trees, or anytime you need:
 
 ## Examples
 
-||||
-|:--|:--|:--|
-|two_billion_rows|canvas_data_model|perspective|
-|[![two_billion_rows](https://bl.ocks.org/texodus/raw/483a42e7b877043714e18bea6872b039/thumbnail.png)](https://bl.ocks.org/texodus/483a42e7b877043714e18bea6872b039)|[![canvas_data_model](https://bl.ocks.org/texodus/raw/4c6537e23dff3c8f97c316559cef012e/thumbnail.png)](https://bl.ocks.org/texodus/4c6537e23dff3c8f97c316559cef012e)|[![perspective](https://bl.ocks.org/texodus/raw/d92520387cb7aa5752dad7286cbb89c9/thumbnail.png)](https://bl.ocks.org/texodus/d92520387cb7aa5752dad7286cbb89c9)|
+|||||
+|:--|:--|:--|:--|
+|two_billion_rows|canvas_data_model|perspective|file_browser|
+|[![two_billion_rows](https://bl.ocks.org/texodus/raw/483a42e7b877043714e18bea6872b039/thumbnail.png)](https://bl.ocks.org/texodus/483a42e7b877043714e18bea6872b039)|[![canvas_data_model](https://bl.ocks.org/texodus/raw/4c6537e23dff3c8f97c316559cef012e/thumbnail.png)](https://bl.ocks.org/texodus/4c6537e23dff3c8f97c316559cef012e)|[![perspective](https://bl.ocks.org/texodus/raw/d92520387cb7aa5752dad7286cbb89c9/thumbnail.png)](https://bl.ocks.org/texodus/d92520387cb7aa5752dad7286cbb89c9)|[![file_browser](https://bl.ocks.org/telamonian/raw/a0c536b6e9f96aa0414436949a380b98/thumbnail.png)](https://bl.ocks.org/telamonian/a0c536b6e9f96aa0414436949a380b98)|
 
 ## Installation
 
@@ -56,7 +56,7 @@ import "regular-table/dist/css/material.css";
 
 ## Custom Element
 
-`regular-table` exports no symbols, only the `<regular-table>` Custom Element 
+`regular-table` exports no symbols, only the `<regular-table>` Custom Element
 which is registered as a module import side-effect.  Once loaded,
 `<regular-table>` can be used just like any other `HTMLElement`, using regular
 browser APIs:
@@ -90,13 +90,13 @@ indirectly.
 
 ```javascript
 const COLUMN_NAMES = [
-    "Column 1 (number)", 
+    "Column 1 (number)",
     "Column 2 (string)",
     "Column 3 (boolean)",
 ];
 
 const DATA = [
-    [0, 1, 2, 3, 4, 5], 
+    [0, 1, 2, 3, 4, 5],
     ["A", "B", "C", "D", "E", "F"],
     [true, false, true, false, true, false]
 ];
@@ -105,8 +105,8 @@ const DATA = [
 Here's a simple _virtual_ data model for this example, the function
 `getDataSlice()`.  This function is called by your `<regular-table>` whenever it
 needs more data, with coordinate arguments, `(x0, y0)` to `(x1, y1)`.  Only
-this region is needed to render the viewport, so `getDataSlice()` returns 
-this rectangular `slice` of `DATA`, as well as overall dimensions the overall 
+this region is needed to render the viewport, so `getDataSlice()` returns
+this rectangular `slice` of `DATA`, as well as overall dimensions the overall
 dimensions of `DATA` itself ( `num_rows`, `num_columns`), for sizing the
 virtual scroll area:
 
@@ -116,11 +116,11 @@ function getDataSlice(x0, y0, x1, y1) {
     const column_indices = COLUMN_NAMES.slice(x0, x1);
     const num_columns = DATA.length;
     const num_rows = DATA[0].length;
-  
+
     return {
         num_rows,
         num_columns,
-        column_indices, 
+        column_indices,
         data
     };
 }
@@ -186,11 +186,11 @@ worker.addEventListener("message", event => {
 });
 
 regularTable.setDataModel((...viewport) => {
-    return new Promise(function (resolve) {    
+    return new Promise(function (resolve) {
         callback = resolve;
         worker.postMessage(viewport);
     });
-}); 
+});
 ```
 
 This example works by calling a simple remote call wrapper to
@@ -228,7 +228,7 @@ Start the example server at [`http://localhost:8080/examples/`](http://localhost
 ```bash
 yarn start
 ```
-<!-- 
+<!--
 ## Stats
 
 [![Build Status](https://travis-ci.org/jpmorganchase/regular-table.svg?branch=master)](https://travis-ci.org/jpmorganchase/regular-table)

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -62,8 +62,17 @@
         }
 
         function popContents(rix, arr) {
-            const contents = getContents(arr[rix].path, true);
-            arr.splice(rix + 1, contents.contents.length);
+            const {path} = arr[rix]
+            const contents = getContents(path, true);
+
+            // pop out the contents of the collapsed node and any expanded subnodes
+            let npop = contents.contents.length;
+            let check_ix = rix + 1 + npop;
+            while (arr[check_ix++].path.length > path.length) {
+                npop++;
+            }
+
+            arr.splice(rix + 1, npop);
         }
 
         let rows = getContents([], true).contents;

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -24,11 +24,10 @@
 
         const NUM_ROWS = 100;
         const NUM_DIR = 10;
-        const NUM_FILE = NUM_ROWS - NUM_DIR;
 
-        const COLUMN_NAMES = ['modified', 'writable'];
-
-        const formatter = new Intl.DateTimeFormat("en-us");
+        const COLUMN_NAMES = ['modified', 'kind', 'writable'];
+        const DIR_NAMES = ['able', 'baker', 'charlie', 'dog', 'easy', 'fox', 'george', 'how', 'item', 'jig', 'king', 'love', 'mike', 'nan', 'oboe', 'peter', 'queen', 'roger', 'sugar', 'tare', 'uncle', 'victor', 'william', 'xray', 'yoke', 'zebra'];
+        const date_formatter = new Intl.DateTimeFormat("en-us");
 
         const _contents_cache = new Map();
         function getContents(path, expand) {
@@ -37,7 +36,11 @@
             if (_contents_cache.has(path)) {
                 contents = _contents_cache.get(path);
             } else {
-                contents = {path, modified: new Date(1000), writable: false};
+                contents = {
+                    path,
+                    modified: new Date(1000),
+                    kind: 'dir',
+                    writable: false};
                 _contents_cache.set(path, contents);
             }
 
@@ -45,46 +48,54 @@
                 return contents;
             }
 
-            let sub = []
+            contents.contents = []
             for (let i = 0; i < NUM_ROWS; i ++) {
-                sub.push({
-                    path: [...path, i < NUM_DIR ? `${i}/` : `${i}.txt`],
-                    modified: new Date(1000*86400*i),
+                const subcontents = {
+                    path: [...path, i < NUM_DIR ? `${DIR_NAMES[i]}/` : `file_${i - NUM_DIR}.txt`],
+                    modified: new Date(contents.modified.getTime() + 24*60*60*1000*(365 + i)),
+                    kind: i < NUM_DIR ? 'dir' : 'text',
                     writable: false,
-                });
+                };
+
+                _contents_cache.set(subcontents.path, subcontents);
+                contents.contents.push(subcontents);
             }
 
-            contents.contents = sub;
             return contents;
         }
 
-        function insertContents(rix, arr) {
-            const contents = getContents(arr[rix].path, true);
-            arr.splice(rix, 0, ...contents.contents);
+        let config = {
+            column_pivots: [],
+            row_pivots: ['path'],
         }
 
-        function popContents(rix, arr) {
-            const {path} = arr[rix]
-            const contents = getContents(path, true);
+        let rows = getContents([], true).contents;
+
+        // for tree support
+        async function collapse(rix) {
+            const contents = getContents(rows[rix].path);
 
             // pop out the contents of the collapsed node and any expanded subnodes
             let npop = contents.contents.length;
             let check_ix = rix + 1 + npop;
-            while (arr[check_ix++].path.length > path.length) {
+            while (rows[check_ix++].path.length > contents.path.length) {
                 npop++;
             }
 
-            arr.splice(rix + 1, npop);
+            rows.splice(rix + 1, npop);
         }
 
-        let rows = getContents([], true).contents;
+        async function expand(rix) {
+            const contents = getContents(rows[rix].path, true);
+            rows.splice(rix + 1, 0, ...contents.contents);
+        }
 
         async function file_browser_model(start_col, start_row, end_col, end_row) {
             const data = [];
             for (let cix = start_col; cix < end_col; cix ++) {
                 const name = COLUMN_NAMES[cix];
                 data.push(rows.slice(start_row, end_row).map(c => {
-                    return name === 'modified' ? formatter.format(c[name]) : c[name];
+                    return name === 'modified' ? date_formatter.format(c[name]) : c[name];
                 }));
             }
 
@@ -94,21 +105,14 @@
                 column_indices: COLUMN_NAMES.map(col => [col]),
                 row_indices: rows.slice(start_row, end_row).map(c => c['path']),
                 data,
+                __collapse: collapse,
+                __config: config,
+                __expand: expand,
             };
         }
 
-        // for tree support
-        file_browser_model.collapse = async rix => {
-            popContents(rix, rows);
-        }
-        file_browser_model.expand = async rix => {
-            insertContents(rix + 1, rows);
-        }
-
         const table = document.getElementsByTagName('regular-table')[0];
-        table.setDataModel(file_browser_model).then(() => {
-            table._view_cache.config.row_pivots = ['name']
-        });
+        table.setDataModel(file_browser_model);
     </script>
 
 </body>

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -25,7 +25,7 @@
         const NUM_DIR = 10;
         const NUM_FILE = NUM_ROWS - NUM_DIR;
 
-        const COLUMN_NAMES = ['__ROW_PATH__', 'modified', 'writable'];
+        const COLUMN_NAMES = ['modified', 'writable'];
         const SCHEMA = {'name': 'string', 'modified': 'date', 'writable': 'string'};
 
         const _contents_cache = new Map();
@@ -77,39 +77,38 @@
 
         let rows = getContents([], true).contents;
 
-        window.addEventListener('DOMContentLoaded', async function () {
-            const table = document.getElementsByTagName('regular-table')[0];
-            await table.set_view({
-                schema: async () => SCHEMA
-            }, {
-                num_rows: async () => rows.length,
-                column_paths: async () => COLUMN_NAMES,
-                get_config: async () => {
-                    return {
-                         row_pivots: ['name'],
-                         column_pivots: []
-                    };
-                },
-                to_columns: ({start_row, end_row, start_col, end_col}) => {
-                    const columns = {};
-                    for (let cix = start_col; cix < end_col; cix ++) {
-                        const name = COLUMN_NAMES[cix];
-                        columns[name] = rows.slice(start_row, end_row).map(c => c[name === '__ROW_PATH__' ? 'path' : name]);
-                    }
+        async function file_browser_model(start_col, start_row, end_col, end_row) {
+            const data = [];
+            for (let cix = start_col; cix < end_col; cix ++) {
+                const name = COLUMN_NAMES[cix];
+                data.push(
+                    rows.slice(start_row, end_row).map(c => c[name])
+                );
+            }
 
-                    return columns;
-                },
-                schema: async () => {
-                    return SCHEMA;
-                },
-                collapse: rix => {
-                    popContents(rix, rows);
-                },
-                expand: rix => {
-                    insertContents(rix + 1, rows);
-                }
-            });
-            await table.draw();
+            return {
+                num_rows: rows.length,
+                num_columns: COLUMN_NAMES.length,
+                column_indices: COLUMN_NAMES.map(col => [col]),
+                row_indices: rows.slice(start_row, end_row).map(c => c['path']),
+                data,
+            };
+        }
+
+        // for tree support
+        file_browser_model.collapse = rix => {
+            popContents(rix, rows);
+        };
+        file_browser_model.expand = rix => {
+            insertContents(rix + 1, rows);
+        }
+
+        const table = document.getElementsByTagName('regular-table')[0];
+        table.setDataModel(file_browser_model).then(() => {
+            table._view_cache.config = {
+                row_pivots: ['name'],
+                column_pivots: []
+            };
         });
     </script>
 

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -21,12 +21,14 @@
     <regular-table></regular-table>
 
     <script>
+
         const NUM_ROWS = 100;
         const NUM_DIR = 10;
         const NUM_FILE = NUM_ROWS - NUM_DIR;
 
         const COLUMN_NAMES = ['modified', 'writable'];
-        const SCHEMA = {'name': 'string', 'modified': 'date', 'writable': 'string'};
+
+        const formatter = new Intl.DateTimeFormat("en-us");
 
         const _contents_cache = new Map();
         function getContents(path, expand) {
@@ -81,9 +83,9 @@
             const data = [];
             for (let cix = start_col; cix < end_col; cix ++) {
                 const name = COLUMN_NAMES[cix];
-                data.push(
-                    rows.slice(start_row, end_row).map(c => c[name])
-                );
+                data.push(rows.slice(start_row, end_row).map(c => {
+                    return name === 'modified' ? formatter.format(c[name]) : c[name];
+                }));
             }
 
             return {
@@ -96,19 +98,16 @@
         }
 
         // for tree support
-        file_browser_model.collapse = rix => {
+        file_browser_model.collapse = async rix => {
             popContents(rix, rows);
-        };
-        file_browser_model.expand = rix => {
+        }
+        file_browser_model.expand = async rix => {
             insertContents(rix + 1, rows);
         }
 
         const table = document.getElementsByTagName('regular-table')[0];
         table.setDataModel(file_browser_model).then(() => {
-            table._view_cache.config = {
-                row_pivots: ['name'],
-                column_pivots: []
-            };
+            table._view_cache.config.row_pivots = ['name']
         });
     </script>
 

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -35,7 +35,7 @@
             if (_contents_cache.has(path)) {
                 contents = _contents_cache.get(path);
             } else {
-                contents = {path, modified: new Date(1000*i), writable: false};
+                contents = {path, modified: new Date(1000), writable: false};
                 _contents_cache.set(path, contents);
             }
 
@@ -47,7 +47,7 @@
             for (let i = 0; i < NUM_ROWS; i ++) {
                 sub.push({
                     path: [...path, i < NUM_DIR ? `${i}/` : `${i}.txt`],
-                    date: new Date(1000*i),
+                    modified: new Date(1000*86400*i),
                     writable: false,
                 });
             }
@@ -63,10 +63,10 @@
 
         function popContents(rix, arr) {
             const contents = getContents(arr[rix].path, true);
-            arr.splice(rix, contents.contents.length);
+            arr.splice(rix + 1, contents.contents.length);
         }
 
-        let rows = getContents([], true);
+        let rows = getContents([], true).contents;
 
         window.addEventListener('DOMContentLoaded', async function () {
             const table = document.getElementsByTagName('regular-table')[0];
@@ -84,8 +84,8 @@
                 to_columns: ({start_row, end_row, start_col, end_col}) => {
                     const columns = {};
                     for (let cix = start_col; cix < end_col; cix ++) {
-                        const name = COLUMN_NAMES[i];
-                        columns[name] = rows.slice(start_row, end_row).map(c => c[name === '___ROW__PATH__' ? 'name' : name]);
+                        const name = COLUMN_NAMES[cix];
+                        columns[name] = rows.slice(start_row, end_row).map(c => c[name === '__ROW_PATH__' ? 'path' : name]);
                     }
 
                     return columns;
@@ -93,11 +93,11 @@
                 schema: async () => {
                     return SCHEMA;
                 },
-                colapse: rix => {
+                collapse: rix => {
                     popContents(rix, rows);
                 },
                 expand: rix => {
-                    insertContents(rix, rows);
+                    insertContents(rix + 1, rows);
                 }
             });
             await table.draw();

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -1,0 +1,109 @@
+<!--
+
+   Copyright (c) 2020, the Regular Table Authors.
+
+   This file is part of the Regular Table library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <script src="../umd/regular-table.js"></script>
+    <link rel='stylesheet' href="../css/material.css">
+</head>
+
+<body>
+
+    <regular-table></regular-table>
+
+    <script>
+        const NUM_ROWS = 100;
+        const NUM_DIR = 10;
+        const NUM_FILE = NUM_ROWS - NUM_DIR;
+
+        const COLUMN_NAMES = ['__ROW_PATH__', 'modified', 'writable'];
+        const SCHEMA = {'name': 'string', 'modified': 'date', 'writable': 'string'};
+
+        const _contents_cache = new Map();
+        function getContents(path, expand) {
+            // infinite recursive mock contents
+            let contents;
+            if (_contents_cache.has(path)) {
+                contents = _contents_cache.get(path);
+            } else {
+                contents = {path, modified: new Date(1000*i), writable: false};
+                _contents_cache.set(path, contents);
+            }
+
+            if (!expand || 'contents' in contents) {
+                return contents;
+            }
+
+            let sub = []
+            for (let i = 0; i < NUM_ROWS; i ++) {
+                sub.push({
+                    path: [...path, i < NUM_DIR ? `${i}/` : `${i}.txt`],
+                    date: new Date(1000*i),
+                    writable: false,
+                });
+            }
+
+            contents.contents = sub;
+            return contents;
+        }
+
+        function insertContents(rix, arr) {
+            const contents = getContents(arr[rix].path, true);
+            arr.splice(rix, 0, ...contents.contents);
+        }
+
+        function popContents(rix, arr) {
+            const contents = getContents(arr[rix].path, true);
+            arr.splice(rix, contents.contents.length);
+        }
+
+        let rows = getContents([], true);
+
+        window.addEventListener('DOMContentLoaded', async function () {
+            const table = document.getElementsByTagName('regular-table')[0];
+            await table.set_view({
+                schema: async () => SCHEMA
+            }, {
+                num_rows: async () => rows.length,
+                column_paths: async () => COLUMN_NAMES,
+                get_config: async () => {
+                    return {
+                         row_pivots: ['name'],
+                         column_pivots: []
+                    };
+                },
+                to_columns: ({start_row, end_row, start_col, end_col}) => {
+                    const columns = {};
+                    for (let cix = start_col; cix < end_col; cix ++) {
+                        const name = COLUMN_NAMES[i];
+                        columns[name] = rows.slice(start_row, end_row).map(c => c[name === '___ROW__PATH__' ? 'name' : name]);
+                    }
+
+                    return columns;
+                },
+                schema: async () => {
+                    return SCHEMA;
+                },
+                colapse: rix => {
+                    popContents(rix, rows);
+                },
+                expand: rix => {
+                    insertContents(rix, rows);
+                }
+            });
+            await table.draw();
+        });
+    </script>
+
+</body>
+
+</html>

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -38,7 +38,7 @@
             } else {
                 contents = {
                     path,
-                    modified: new Date(1000),
+                    modified: new Date(12*60*60*1000),
                     kind: 'dir',
                     writable: false};
                 _contents_cache.set(path, contents);

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -14,6 +14,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <script src="../dist/umd/regular-table.js"></script>
     <link rel='stylesheet' href="../dist/css/material.css">
+
+    <style>
+        .rt-browser-icon:before {
+            content: "";
+            float: left;
+            margin-right: 5px;
+            margin-left: -10px;
+            min-width: 16px;
+            min-height: 16px;
+        }
+
+        .rt-browser-dir-icon:before {
+            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+PC9zdmc+");
+        }
+
+        .rt-browser-text-icon:before {
+            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+PC9zdmc+");
+        }
+    </style>
 </head>
 
 <body>
@@ -111,8 +130,30 @@
             };
         }
 
-        const table = document.getElementsByTagName('regular-table')[0];
-        table.setDataModel(file_browser_model);
+        window.addEventListener('DOMContentLoaded', async function () {
+            const table = document.getElementsByTagName('regular-table')[0];
+            await table.setDataModel(file_browser_model);
+
+            table.addEventListener("regular-table-after-update", function () {
+                const trs = table.querySelectorAll("tr");
+                for (const tr of trs) {
+                    const {children} = tr;
+                    const row_name_node = children[0].querySelector('.pd-group-name');
+                    for (let i = 1; i < children.length; i ++) {
+                        const text = children[i].textContent;
+                        if (text === 'dir') {
+                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-dir-icon');
+                            break;
+                        } else if (text === 'text') {
+                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-text-icon');
+                            break;
+                        }
+                    }
+                }
+            });
+
+            await table.draw();
+        });
     </script>
 
 </body>

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -12,8 +12,8 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
-    <script src="../umd/regular-table.js"></script>
-    <link rel='stylesheet' href="../css/material.css">
+    <script src="../dist/umd/regular-table.js"></script>
+    <link rel='stylesheet' href="../dist/css/material.css">
 </head>
 
 <body>
@@ -75,7 +75,7 @@
         async function collapse(rix) {
             const contents = getContents(rows[rix].path);
 
-            // pop out the contents of the collapsed node and any expanded subnodes
+            // splice out the contents of the collapsed node and any expanded subnodes
             let npop = contents.contents.length;
             let check_ix = rix + 1 + npop;
             while (rows[check_ix++].path.length > contents.path.length) {

--- a/examples/perspective.html
+++ b/examples/perspective.html
@@ -1,7 +1,7 @@
 <!--
-   
+
    Copyright (c) 2020, the Regular Table Authors.
-   
+
    This file is part of the Regular Table library, distributed under the terms of
    the Apache License 2.0.  The full license can be found in the LICENSE file.
 
@@ -22,7 +22,7 @@
     <regular-table></regular-table>
 
     <script>
-        
+
         const URL = "https://unpkg.com/@jpmorganchase/perspective-examples/build/superstore.arrow";
 
         const datasource = async () => {
@@ -39,9 +39,9 @@
                 let columns = {};
                 if (x1 - x0 > 0 && y1 - y0 > 0) {
                     columns = await this.view.to_columns({
-                        start_row: y0, 
-                        start_col: x0, 
-                        end_row: y1, 
+                        start_row: y0,
+                        start_col: x0,
+                        end_row: y1,
                         end_col: x1,
                         id: this._config.row_pivots.length > 0
                     });
@@ -56,8 +56,11 @@
 
                 return {
                     __id_column: columns.__ID__,
+                    __collapse: this._collapse,
                     __config: this._config,
-                    __schema: this._schema,
+                    __expand: this._expand,
+                    __schema: this.table_schema,
+                    __set_depth: this._set_depth,
                     num_rows: this._num_rows,
                     num_columns: this._column_paths.length,
                     row_indices: columns.__ROW_PATH__,
@@ -69,19 +72,22 @@
             async set_view(table, view) {
                 this.view = view;
                 this.table_schema = await table.schema();
+                this._collapse = view.collapse;
                 this._config = await view.get_config();
+                this._expand = view.expand;
                 this._num_rows = await view.num_rows();
                 this._schema = await view.schema();
+                this._set_depth = view.set_depth;
                 this._column_paths = await view.column_paths()
                 this._column_paths = this._column_paths.filter(path => {
                     return path !== "__ROW_PATH__" && path !== "__ID__";
                 });
             }
         }
-            
+
         window.addEventListener('DOMContentLoaded', async function () {
             const table = await datasource();
-            const view = table.view();
+            const view = table.view({row_pivots: ["Region", "State", "City"]});
             const data_model = new PerspectiveDataModel();
             await data_model.set_view(table, view);
 

--- a/src/js/custom_element.js
+++ b/src/js/custom_element.js
@@ -64,7 +64,7 @@ export class RegularViewModel extends RegularViewEventModel {
      * @memberof RegularViewModel
      */
     get_ths() {
-        return this.table_model.body.cells.flat(1);
+        return this.table_model.header.cells.flat(1);
     }
 
     /**

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -257,15 +257,15 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
     async _on_toggle(event, metadata) {
         if (metadata.is_open) {
             if (event.shiftKey) {
-                await this._view_cache.view.set_depth(metadata.row_path.length - 1);
+                await this._view_cache.set_depth(metadata.row_path.length - 1);
             } else {
-                await this._view_cache.view.collapse(metadata.ridx);
+                await this._view_cache.collapse(metadata.ridx);
             }
         } else if (metadata.is_open === false) {
             if (event.shiftKey) {
-                await this._view_cache.view.set_depth(metadata.row_path.length);
+                await this._view_cache.set_depth(metadata.row_path.length);
             } else {
-                await this._view_cache.view.expand(metadata.ridx);
+                await this._view_cache.expand(metadata.ridx);
             }
         }
         await this.draw({invalid_viewport: true});

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -387,10 +387,18 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this.reset_scroll();
         }
 
-        const {num_columns, num_rows, __config, __schema} = await this._view_cache.view(0, 0, 0, 0);
+        const {num_columns, num_rows, __collapse, __config, __expand, __schema} = await this._view_cache.view(0, 0, 0, 0);
+
+        if (__collapse) {
+            this._view_cache.collapse = __collapse;
+        }
 
         if (__config) {
             this._view_cache.config = __config;
+        }
+
+        if (__expand) {
+            this._view_cache.expand = __expand;
         }
 
         if (__schema) {

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -387,7 +387,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this.reset_scroll();
         }
 
-        const {num_columns, num_rows, __collapse, __config, __expand, __schema} = await this._view_cache.view(0, 0, 0, 0);
+        const {num_columns, num_rows, __collapse, __config, __expand, __schema, __set_depth} = await this._view_cache.view(0, 0, 0, 0);
 
         if (__collapse) {
             this._view_cache.collapse = __collapse;
@@ -403,6 +403,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
 
         if (__schema) {
             this._view_cache.schema = __schema;
+        }
+
+        if (__set_depth) {
+            this._view_cache.set_depth = __set_depth;
         }
 
         if (this._virtual_scrolling_disabled) {

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -52,7 +52,7 @@ export class RegularBodyViewModel extends ViewModel {
             metadata.value = null;
             metadata.row_path = null;
         } else if (formatter) {
-            formatter.format(td, val, type, val.length === depth, is_open);
+            formatter.format(td, val, type, val.length >= depth, is_open);
             metadata.value = Array.isArray(val) ? val[val.length - 1] : val;
             metadata.row_path = id;
             metadata.is_open = is_open;

--- a/src/js/tree_row_header.js
+++ b/src/js/tree_row_header.js
@@ -38,6 +38,11 @@ function _tree_header_levels(path, is_open, is_leaf) {
 export function tree_header(td, path, types, is_leaf, is_open) {
     const type = types[path.length - 1];
     const name = path.length === 0 ? "TOTAL" : path[path.length - 1];
+
+    if (path.length && path[0].endsWith('/')) {
+        is_leaf = false;
+    }
+
     const header_classes = _tree_header_classes.call(this, name, type, is_leaf);
     const tree_levels = _tree_header_levels(path, is_open, is_leaf);
     const header_text = this._format_text(type)(name);

--- a/src/js/tree_row_header.js
+++ b/src/js/tree_row_header.js
@@ -39,7 +39,7 @@ export function tree_header(td, path, types, is_leaf, is_open) {
     const type = types[path.length - 1];
     const name = path.length === 0 ? "TOTAL" : path[path.length - 1];
 
-    if (path.length && path[0].endsWith('/')) {
+    if (path.length && path[path.length - 1].endsWith("/")) {
         is_leaf = false;
     }
 

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -8,7 +8,8 @@
  *
  */
 
-@import (css) url("https://fonts.googleapis.com/css?family=Open+Sans");
+ @import (css) url("https://fonts.googleapis.com/css?family=Material+Icons");
+ @import (css) url("https://fonts.googleapis.com/css?family=Open+Sans");
 
 @row-height: 19px;
 

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2020, the Regular Table Authors.
+ *
+ * This file is part of the Regular Table library, distributed under the terms
+ * of the Apache License 2.0.  The full license can be found in the LICENSE
+ * file.
+ *
+ */
+
+describe("file_browser.html", () => {
+    beforeAll(async () => {
+        await page.setViewport({width: 400, height: 100});
+    });
+
+    describe("creates a `<table>` body when attached to `document`", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
+
+        test("with the correct # of rows", async () => {
+            const tbody = await page.$("regular-table tbody");
+            const num_rows = await page.evaluate((tbody) => tbody.children.length, tbody);
+            expect(num_rows).toEqual(5);
+        });
+
+        test("with the correct # of columns", async () => {
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const num_cells = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
+            expect(num_cells).toEqual(4);
+        });
+
+        test("with the first row's cell test correct", async () => {
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "add able/",
+                "1/1/1971",
+                "dir",
+                "false"
+            ]);
+        });
+    });
+
+    describe("scrolls via scrollTo() method", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
+
+        test("to (0, 1)", async () => {
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                table.scrollTo(0, 1, 3, 26);
+                await table.draw();
+            }, table);
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "add easy/",
+                "1/5/1971",
+                "dir",
+                "false",
+            ]);
+        });
+
+        test("to (0, 4)", async () => {
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                table.scrollTo(0, 4, 3, 26);
+                await table.draw();
+            }, table);
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "file_6.txt",
+                "1/17/1971",
+                "text",
+                "false",
+            ]);
+        });
+    });
+
+    // TODO: get the expand/collapse tests working
+    // describe("expands and collapses directory nodes", () => {
+    //     beforeAll(async () => {
+    //         await page.goto("http://localhost:8081/examples/file_browser.html");
+    //         await page.waitFor("regular-table table tbody tr td");
+    //     });
+
+    //     test("expands the first directory node", async () => {
+    //         const first_row_header_icon = await page.$("regular-table tbody tr:first-child .pd-row-header-icon");
+    //         await first_row_header_icon.evaluate((x) => x.click());
+
+    //         // test the contents of the first and last nodes added by the expansion
+    //         let tr = await page.$("regular-table tbody tr:nth-child(2)");
+    //         let cell_values = await page.evaluate((tr) => Array.from(tr.children).map((x) => x.textContent.trim()), tr);
+    //         expect(cell_values).toEqual([
+    //             "add able/",
+    //             "12/31/1970",
+    //             "dir",
+    //             "false"
+    //         ]);
+
+    //         tr = await page.$("regular-table tbody tr:nth-child(101)");
+    //         cell_values = await page.evaluate((tr) => Array.from(tr.children).map((x) => x.textContent.trim()), tr);
+    //         expect(cell_values).toEqual([
+    //             "add able/",
+    //             "12/31/1970",
+    //             "dir",
+    //             "false"
+    //         ]);
+    //     });
+    // });
+});

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -21,14 +21,14 @@ describe("file_browser.html", () => {
 
         test("with the correct # of rows", async () => {
             const tbody = await page.$("regular-table tbody");
-            const num_rows = await page.evaluate((tbody) => tbody.children.length, tbody);
-            expect(num_rows).toEqual(5);
+            const num_rows_rendered = await page.evaluate((tbody) => tbody.children.length, tbody);
+            expect(num_rows_rendered).toEqual(5);
         });
 
         test("with the correct # of columns", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
-            const num_cells = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
-            expect(num_cells).toEqual(4);
+            const num_cells_rendered = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
+            expect(num_cells_rendered).toEqual(4);
         });
 
         test("with the first row's cell test correct", async () => {
@@ -52,65 +52,144 @@ describe("file_browser.html", () => {
         test("to (0, 1)", async () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
-                table.scrollTo(0, 1, 3, 26);
+                table.scrollTo(0, 1, 4, 100);
                 await table.draw();
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
             expect(cell_values).toEqual([
-                "add easy/",
-                "1/5/1971",
+                "add baker/",
+                "1/2/1971",
                 "dir",
                 "false",
             ]);
         });
 
-        test("to (0, 4)", async () => {
+        test("to (0, 79)", async () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
-                table.scrollTo(0, 4, 3, 26);
+                table.scrollTo(0, 79, 4, 100);
                 await table.draw();
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
             expect(cell_values).toEqual([
-                "file_6.txt",
-                "1/17/1971",
+                "file_69.txt",
+                "3/21/1971",
                 "text",
                 "false",
             ]);
         });
     });
 
-    // TODO: get the expand/collapse tests working
-    // describe("expands and collapses directory nodes", () => {
-    //     beforeAll(async () => {
-    //         await page.goto("http://localhost:8081/examples/file_browser.html");
-    //         await page.waitFor("regular-table table tbody tr td");
-    //     });
+    describe("expands and collapses tree rows", () => {
+        const first_tr_selector = "regular-table tbody tr:first-child";
+        const first_row_header_icon_selector = `${first_tr_selector} .pd-row-header-icon`;
 
-    //     test("expands the first directory node", async () => {
-    //         const first_row_header_icon = await page.$("regular-table tbody tr:first-child .pd-row-header-icon");
-    //         await first_row_header_icon.evaluate((x) => x.click());
+        beforeAll(async () => {
+            // refresh page
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
 
-    //         // test the contents of the first and last nodes added by the expansion
-    //         let tr = await page.$("regular-table tbody tr:nth-child(2)");
-    //         let cell_values = await page.evaluate((tr) => Array.from(tr.children).map((x) => x.textContent.trim()), tr);
-    //         expect(cell_values).toEqual([
-    //             "add able/",
-    //             "12/31/1970",
-    //             "dir",
-    //             "false"
-    //         ]);
+        describe("expands", () => {
+            beforeAll(async () => {
+                // expand first directory row
+                let first_row_header_icon = await page.$(first_row_header_icon_selector);
+                await first_row_header_icon.click();
+            });
 
-    //         tr = await page.$("regular-table tbody tr:nth-child(101)");
-    //         cell_values = await page.evaluate((tr) => Array.from(tr.children).map((x) => x.textContent.trim()), tr);
-    //         expect(cell_values).toEqual([
-    //             "add able/",
-    //             "12/31/1970",
-    //             "dir",
-    //             "false"
-    //         ]);
-    //     });
-    // });
+            afterAll(async () => {
+                // reset scroll position
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    await table.draw({reset_scroll_position: true});
+                }, table);
+            });
+
+            test("expand the first tree row", async () => {
+                // test the tree header icon
+                const first_row_header_icon = await page.$(first_row_header_icon_selector);
+                const icon_text = await page.evaluate((x) => x.innerText, first_row_header_icon);
+                expect(icon_text).toEqual("remove");
+            });
+
+            test("first row added by expand is correct", async () => {
+                // scroll to and test first row added by expand
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 1, 4, 200);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "add able/",
+                    "1/1/1972",
+                    "dir",
+                    "false"
+                ]);
+            });
+
+            test("last row added by expand is correct", async () => {
+                // scroll to and test first row added by expand
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 100, 4, 200);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "file_89.txt",
+                    "4/9/1972",
+                    "text",
+                    "false"
+                ]);
+            });
+        });
+
+        describe("collapses", () => {
+            beforeAll(async () => {
+                // collapse first directory row
+                let first_row_header_icon = await page.$(first_row_header_icon_selector);
+                await first_row_header_icon.click();
+            });
+
+            afterAll(async () => {
+                // reset scroll position
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    await table.draw({reset_scroll_position: true});
+                }, table);
+            });
+
+            test("collapse the first tree row", async () => {
+                // test the tree header icon
+                first_row_header_icon = await page.$(first_row_header_icon_selector);
+                const icon_text = await page.evaluate((x) => x.innerText, first_row_header_icon);
+                expect(icon_text).toEqual("add");
+            });
+
+            test("collapse restores previous rows", async () => {
+                // scroll to and test the next row after the collapsed row
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 1, 4, 100);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "add baker/",
+                    "1/2/1971",
+                    "dir",
+                    "false"
+                ]);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Adds an example of regular-table being used to render a filebrowser, complete with a tree column on the left. Still needs a bunch of work to be functional, and then a whole bunch of styling work beyond that. I'd also like to figure out how to add some "sort on header click" behavior.

I want to explore adding multiselect and drag-n-drop behavior to this example filebrowser, but those are complex and I may end up saving them for their own individual examples.