### PR TITLE
Adds file_browser.html example (update for `row_headers` feature)

### DIFF
--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -32,6 +32,10 @@
         .rt-browser-text-icon:before {
             background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+PC9zdmc+");
         }
+
+        table {
+            cursor: default;
+        }
     </style>
 </head>
 
@@ -40,119 +44,181 @@
     <regular-table></regular-table>
 
     <script>
-
         const NUM_ROWS = 100;
         const NUM_DIR = 10;
 
-        const COLUMN_NAMES = ['modified', 'kind', 'writable'];
-        const DIR_NAMES = ['able', 'baker', 'charlie', 'dog', 'easy', 'fox', 'george', 'how', 'item', 'jig', 'king', 'love', 'mike', 'nan', 'oboe', 'peter', 'queen', 'roger', 'sugar', 'tare', 'uncle', 'victor', 'william', 'xray', 'yoke', 'zebra'];
-        const date_formatter = new Intl.DateTimeFormat("en-us");
+        const DIR_NAMES = [
+            "able",
+            "baker",
+            "charlie",
+            "dog",
+            "easy",
+            "fox",
+            "george",
+            "how",
+            "item",
+            "jig",
+            "king",
+            "love",
+            "mike",
+            "nan",
+            "oboe",
+            "peter",
+            "queen",
+            "roger",
+            "sugar",
+            "tare",
+            "uncle",
+            "victor",
+            "william",
+            "xray",
+            "yoke",
+            "zebra",
+        ];
 
-        const _contents_cache = new Map();
-        function getContents(path, expand) {
+        const CONTENTS_CACHE = new Map();
+
+        function getFileSystemContents(path, expand) {
             // infinite recursive mock contents
             let contents;
-            if (_contents_cache.has(path)) {
-                contents = _contents_cache.get(path);
+            if (CONTENTS_CACHE.has(path)) {
+                contents = CONTENTS_CACHE.get(path);
             } else {
                 contents = {
                     path,
-                    modified: new Date(12*60*60*1000),
-                    kind: 'dir',
-                    writable: false};
-                _contents_cache.set(path, contents);
+                    modified: new Date(12 * 60 * 60 * 1000),
+                    kind: "dir",
+                    writable: false,
+                };
+                CONTENTS_CACHE.set(path, contents);
             }
 
-            if (!expand || 'contents' in contents) {
+            if (!expand || "contents" in contents) {
                 return contents;
             }
 
-            contents.contents = []
-            for (let i = 0; i < NUM_ROWS; i ++) {
+            contents.contents = [];
+            for (let i = 0; i < NUM_ROWS; i++) {
                 const subcontents = {
                     path: [...path, i < NUM_DIR ? `${DIR_NAMES[i]}/` : `file_${i - NUM_DIR}.txt`],
-                    modified: new Date(contents.modified.getTime() + 24*60*60*1000*(365 + i)),
-                    kind: i < NUM_DIR ? 'dir' : 'text',
+                    modified: new Date(contents.modified.getTime() + 24 * 60 * 60 * 1000 * (365 + i)),
+                    kind: i < NUM_DIR ? "dir" : "text",
                     writable: false,
                 };
 
-                _contents_cache.set(subcontents.path, subcontents);
+                CONTENTS_CACHE.set(subcontents.path, subcontents);
                 contents.contents.push(subcontents);
             }
 
             return contents;
         }
 
-        let config = {
-            column_pivots: [],
-            row_pivots: ['path'],
-        }
+        window.getFileSystemContents = getFileSystemContents;
+    </script>
 
-        let rows = getContents([], true).contents;
+    <script>
+        const COLUMN_HEADERS = ["modified", "kind", "writable"];
 
-        // for tree support
+        const DATE_FORMATTER = new Intl.DateTimeFormat("en-us");
+        const TEMPLATE = document.createElement("template");
+        const VIEW_STATE = window.getFileSystemContents([], true).contents;
+
+        const TABLE = document.getElementsByTagName("regular-table")[0];
+
+        // Splice out the contents of the collapsed node and any expanded subnodes
         async function collapse(rix) {
-            const contents = getContents(rows[rix].path);
-
-            // splice out the contents of the collapsed node and any expanded subnodes
+            VIEW_STATE[rix].is_open = false;
+            const contents = window.getFileSystemContents(VIEW_STATE[rix].path);
             let npop = contents.contents.length;
             let check_ix = rix + 1 + npop;
-            while (rows[check_ix++].path.length > contents.path.length) {
+            while (VIEW_STATE[check_ix++].path.length > contents.path.length) {
                 npop++;
             }
 
-            rows.splice(rix + 1, npop);
+            VIEW_STATE.splice(rix + 1, npop);
         }
 
         async function expand(rix) {
-            const contents = getContents(rows[rix].path, true);
-            rows.splice(rix + 1, 0, ...contents.contents);
+            VIEW_STATE[rix].is_open = true;
+            const contents = window.getFileSystemContents(VIEW_STATE[rix].path, true);
+            VIEW_STATE.splice(rix + 1, 0, ...contents.contents);
+        }
+
+        function tree_header_levels(path, is_open, is_leaf) {
+            const tree_levels = path.slice(1).map(() => '<span class="pd-tree-group"></span>');
+            if (!is_leaf) {
+                const group_icon = is_open ? "remove" : "add";
+                const tree_button = `<span class="pd-row-header-icon">${group_icon} </span>`;
+                tree_levels.push(tree_button);
+            }
+
+            return tree_levels.join("");
+        }
+
+        function tree_header({path, is_open, kind}) {
+            const name = path.length === 0 ? "TOTAL" : path[path.length - 1];
+            const header_classes = kind === "text" ? "pd-group-name pd-group-leaf" : "pd-group-name";
+            const tree_levels = tree_header_levels(path, is_open, kind === "text");
+            const header_text = name;
+            TEMPLATE.innerHTML = `<span class="pd-tree-container">${tree_levels}<span class="${header_classes}">${header_text}</span></span>`;
+            return TEMPLATE.content.firstChild;
         }
 
         async function file_browser_model(start_col, start_row, end_col, end_row) {
             const data = [];
-            for (let cix = start_col; cix < end_col; cix ++) {
-                const name = COLUMN_NAMES[cix];
-                data.push(rows.slice(start_row, end_row).map(c => {
-                    return name === 'modified' ? date_formatter.format(c[name]) : c[name];
-                }));
+            for (let cix = start_col; cix < end_col; cix++) {
+                const name = COLUMN_HEADERS[cix];
+                data.push(
+                    VIEW_STATE.slice(start_row, end_row).map((c) => {
+                        return name === "modified" ? DATE_FORMATTER.format(c[name]) : c[name];
+                    })
+                );
             }
 
             return {
-                num_rows: rows.length,
-                num_columns: COLUMN_NAMES.length,
-                column_indices: COLUMN_NAMES.map(col => [col]),
-                row_indices: rows.slice(start_row, end_row).map(c => c['path']),
+                num_rows: VIEW_STATE.length,
+                num_columns: COLUMN_HEADERS.length,
+                column_headers: COLUMN_HEADERS.map((col) => [col]),
+                row_headers: VIEW_STATE.slice(start_row, end_row).map((x) => [tree_header(x)]),
                 data,
-                __collapse: collapse,
-                __config: config,
-                __expand: expand,
             };
         }
 
-        window.addEventListener('DOMContentLoaded', async function () {
-            const table = document.getElementsByTagName('regular-table')[0];
-            await table.setDataModel(file_browser_model);
-
-            table.addEventListener("regular-table-after-update", function () {
-                const trs = table.querySelectorAll("tr");
-                for (const tr of trs) {
-                    const {children} = tr;
-                    const row_name_node = children[0].querySelector('.pd-group-name');
-                    for (let i = 1; i < children.length; i ++) {
-                        const text = children[i].textContent;
-                        if (text === 'dir') {
-                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-dir-icon');
-                            break;
-                        } else if (text === 'text') {
-                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-text-icon');
-                            break;
-                        }
+        function file_browser_style() {
+            const trs = TABLE.querySelectorAll("tr");
+            for (const tr of trs) {
+                const {children} = tr;
+                const row_name_node = children[0].querySelector(".pd-group-name");
+                for (let i = 1; i < children.length; i++) {
+                    const text = children[i].textContent;
+                    if (text === "dir") {
+                        row_name_node.classList.add("rt-browser-icon", "rt-browser-dir-icon");
+                        break;
+                    } else if (text === "text") {
+                        row_name_node.classList.add("rt-browser-icon", "rt-browser-text-icon");
+                        break;
                     }
                 }
-            });
+            }
+        }
 
-            await table.draw();
+        function file_browser_on_click(event) {
+            if (event.target.tagName === "SPAN" && event.target.className === "pd-row-header-icon") {
+                const metadata = TABLE.get_meta(event.target.parentElement.parentElement);
+                if (VIEW_STATE[metadata.y].is_open) {
+                    collapse(metadata.y);
+                } else {
+                    expand(metadata.y);
+                }
+                TABLE.draw({invalid_viewport: true});
+            }
+        }
+
+        window.addEventListener("DOMContentLoaded", async function () {
+            await TABLE.setDataModel(file_browser_model);
+            TABLE.addEventListener("regular-table-after-update", file_browser_style);
+            TABLE.addEventListener("click", file_browser_on_click);
+            await TABLE.draw();
         });
     </script>
 

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -1,0 +1,161 @@
+<!--
+
+   Copyright (c) 2020, the Regular Table Authors.
+
+   This file is part of the Regular Table library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <script src="../dist/umd/regular-table.js"></script>
+    <link rel='stylesheet' href="../dist/css/material.css">
+
+    <style>
+        .rt-browser-icon:before {
+            content: "";
+            float: left;
+            margin-right: 5px;
+            margin-left: -10px;
+            min-width: 16px;
+            min-height: 16px;
+        }
+
+        .rt-browser-dir-icon:before {
+            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+PC9zdmc+");
+        }
+
+        .rt-browser-text-icon:before {
+            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+PC9zdmc+");
+        }
+    </style>
+</head>
+
+<body>
+
+    <regular-table></regular-table>
+
+    <script>
+
+        const NUM_ROWS = 100;
+        const NUM_DIR = 10;
+
+        const COLUMN_NAMES = ['modified', 'kind', 'writable'];
+        const DIR_NAMES = ['able', 'baker', 'charlie', 'dog', 'easy', 'fox', 'george', 'how', 'item', 'jig', 'king', 'love', 'mike', 'nan', 'oboe', 'peter', 'queen', 'roger', 'sugar', 'tare', 'uncle', 'victor', 'william', 'xray', 'yoke', 'zebra'];
+        const date_formatter = new Intl.DateTimeFormat("en-us");
+
+        const _contents_cache = new Map();
+        function getContents(path, expand) {
+            // infinite recursive mock contents
+            let contents;
+            if (_contents_cache.has(path)) {
+                contents = _contents_cache.get(path);
+            } else {
+                contents = {
+                    path,
+                    modified: new Date(12*60*60*1000),
+                    kind: 'dir',
+                    writable: false};
+                _contents_cache.set(path, contents);
+            }
+
+            if (!expand || 'contents' in contents) {
+                return contents;
+            }
+
+            contents.contents = []
+            for (let i = 0; i < NUM_ROWS; i ++) {
+                const subcontents = {
+                    path: [...path, i < NUM_DIR ? `${DIR_NAMES[i]}/` : `file_${i - NUM_DIR}.txt`],
+                    modified: new Date(contents.modified.getTime() + 24*60*60*1000*(365 + i)),
+                    kind: i < NUM_DIR ? 'dir' : 'text',
+                    writable: false,
+                };
+
+                _contents_cache.set(subcontents.path, subcontents);
+                contents.contents.push(subcontents);
+            }
+
+            return contents;
+        }
+
+        let config = {
+            column_pivots: [],
+            row_pivots: ['path'],
+        }
+
+        let rows = getContents([], true).contents;
+
+        // for tree support
+        async function collapse(rix) {
+            const contents = getContents(rows[rix].path);
+
+            // splice out the contents of the collapsed node and any expanded subnodes
+            let npop = contents.contents.length;
+            let check_ix = rix + 1 + npop;
+            while (rows[check_ix++].path.length > contents.path.length) {
+                npop++;
+            }
+
+            rows.splice(rix + 1, npop);
+        }
+
+        async function expand(rix) {
+            const contents = getContents(rows[rix].path, true);
+            rows.splice(rix + 1, 0, ...contents.contents);
+        }
+
+        async function file_browser_model(start_col, start_row, end_col, end_row) {
+            const data = [];
+            for (let cix = start_col; cix < end_col; cix ++) {
+                const name = COLUMN_NAMES[cix];
+                data.push(rows.slice(start_row, end_row).map(c => {
+                    return name === 'modified' ? date_formatter.format(c[name]) : c[name];
+                }));
+            }
+
+            return {
+                num_rows: rows.length,
+                num_columns: COLUMN_NAMES.length,
+                column_indices: COLUMN_NAMES.map(col => [col]),
+                row_indices: rows.slice(start_row, end_row).map(c => c['path']),
+                data,
+                __collapse: collapse,
+                __config: config,
+                __expand: expand,
+            };
+        }
+
+        window.addEventListener('DOMContentLoaded', async function () {
+            const table = document.getElementsByTagName('regular-table')[0];
+            await table.setDataModel(file_browser_model);
+
+            table.addEventListener("regular-table-after-update", function () {
+                const trs = table.querySelectorAll("tr");
+                for (const tr of trs) {
+                    const {children} = tr;
+                    const row_name_node = children[0].querySelector('.pd-group-name');
+                    for (let i = 1; i < children.length; i ++) {
+                        const text = children[i].textContent;
+                        if (text === 'dir') {
+                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-dir-icon');
+                            break;
+                        } else if (text === 'text') {
+                            row_name_node.classList.add('rt-browser-icon', 'rt-browser-text-icon');
+                            break;
+                        }
+                    }
+                }
+            });
+
+            await table.draw();
+        });
+    </script>
+
+</body>
+
+</html>

--- a/src/js/custom_element.js
+++ b/src/js/custom_element.js
@@ -64,7 +64,7 @@ export class RegularViewModel extends RegularViewEventModel {
      * @memberof RegularViewModel
      */
     get_ths() {
-        return this.table_model.body.cells.flat(1);
+        return this.table_model.header.cells.flat(1);
     }
 
     /**

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -187,7 +187,7 @@ regular-table, :host {
     }
 
     td th span.pd-group-leaf, th span.pd-group-leaf {
-        margin-left: 12px;
+        margin-left: 16px;
         height: 100%;
     }
 

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -1,0 +1,195 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2020, the Regular Table Authors.
+ *
+ * This file is part of the Regular Table library, distributed under the terms
+ * of the Apache License 2.0.  The full license can be found in the LICENSE
+ * file.
+ *
+ */
+
+describe("file_browser.html", () => {
+    beforeAll(async () => {
+        await page.setViewport({width: 400, height: 100});
+    });
+
+    describe("creates a `<table>` body when attached to `document`", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
+
+        test("with the correct # of rows", async () => {
+            const tbody = await page.$("regular-table tbody");
+            const num_rows_rendered = await page.evaluate((tbody) => tbody.children.length, tbody);
+            expect(num_rows_rendered).toEqual(5);
+        });
+
+        test("with the correct # of columns", async () => {
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const num_cells_rendered = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
+            expect(num_cells_rendered).toEqual(4);
+        });
+
+        test("with the first row's cell test correct", async () => {
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "add able/",
+                "1/1/1971",
+                "dir",
+                "false"
+            ]);
+        });
+    });
+
+    describe("scrolls via scrollTo() method", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
+
+        test("to (0, 1)", async () => {
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                table.scrollTo(0, 1, 4, 100);
+                await table.draw();
+            }, table);
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "add baker/",
+                "1/2/1971",
+                "dir",
+                "false",
+            ]);
+        });
+
+        test("to (0, 79)", async () => {
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                table.scrollTo(0, 79, 4, 100);
+                await table.draw();
+            }, table);
+            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            expect(cell_values).toEqual([
+                "file_69.txt",
+                "3/21/1971",
+                "text",
+                "false",
+            ]);
+        });
+    });
+
+    describe("expands and collapses tree rows", () => {
+        const first_tr_selector = "regular-table tbody tr:first-child";
+        const first_row_header_icon_selector = `${first_tr_selector} .pd-row-header-icon`;
+
+        beforeAll(async () => {
+            // refresh page
+            await page.goto("http://localhost:8081/examples/file_browser.html");
+            await page.waitFor("regular-table table tbody tr td");
+        });
+
+        describe("expands", () => {
+            beforeAll(async () => {
+                // expand first directory row
+                let first_row_header_icon = await page.$(first_row_header_icon_selector);
+                await first_row_header_icon.click();
+            });
+
+            afterAll(async () => {
+                // reset scroll position
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    await table.draw({reset_scroll_position: true});
+                }, table);
+            });
+
+            test("expand the first tree row", async () => {
+                // test the tree header icon
+                const first_row_header_icon = await page.$(first_row_header_icon_selector);
+                const icon_text = await page.evaluate((x) => x.innerText, first_row_header_icon);
+                expect(icon_text).toEqual("remove");
+            });
+
+            test("first row added by expand is correct", async () => {
+                // scroll to and test first row added by expand
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 1, 4, 200);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "add able/",
+                    "1/1/1972",
+                    "dir",
+                    "false"
+                ]);
+            });
+
+            test("last row added by expand is correct", async () => {
+                // scroll to and test first row added by expand
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 100, 4, 200);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "file_89.txt",
+                    "4/9/1972",
+                    "text",
+                    "false"
+                ]);
+            });
+        });
+
+        describe("collapses", () => {
+            beforeAll(async () => {
+                // collapse first directory row
+                let first_row_header_icon = await page.$(first_row_header_icon_selector);
+                await first_row_header_icon.click();
+            });
+
+            afterAll(async () => {
+                // reset scroll position
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    await table.draw({reset_scroll_position: true});
+                }, table);
+            });
+
+            test("collapse the first tree row", async () => {
+                // test the tree header icon
+                first_row_header_icon = await page.$(first_row_header_icon_selector);
+                const icon_text = await page.evaluate((x) => x.innerText, first_row_header_icon);
+                expect(icon_text).toEqual("add");
+            });
+
+            test("collapse restores previous rows", async () => {
+                // scroll to and test the next row after the collapsed row
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTo(0, 1, 4, 100);
+                    await table.draw();
+                }, table);
+
+                const first_tr = await page.$(first_tr_selector);
+                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                expect(cell_values).toEqual([
+                    "add baker/",
+                    "1/2/1971",
+                    "dir",
+                    "false"
+                ]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Updates #19 from @telamonian to rely on the new `row_headers` feature introduced in #24 .  The `add-filebrowser-example` branch was first rebased:

* Commit history was squashed to 1 commit
* Changes to `tree_row_header.js` and 'events.js` were removed.
* Changes to `perspective.html` were removed (which relied on the above).
* README.md changes reverted (no need to add your example to the gallery - I'll do this automatically via script when I dist).

Next, the example was refactored.  Unfortunately some of my comments from the original PR were quickly outdated by rapid progress on this API.

* Removes `__config`, `__collapse` and `__expand` pass-through.
* Uses `row_headers` instead of `row_indices`, et al columns.
* Adds a custom tree_header renderer ala `perspective.html`, modified to handle the lack of an empty 'root' node.
* Adds a click handler to dispatch to `collapse` and `expand()`
* Refactors code into 2 script sections - "fake filesystem generator" and "data model for regular-table" sections.
* General cleanup and lint-powered reformat.

<img width="375" alt="Screen Shot 2020-05-29 at 6 43 41 PM" src="https://user-images.githubusercontent.com/60666/83311148-5938e780-a1dc-11ea-8d6b-1548039b9504.png">

