### PR TITLE
Updated examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ like this, containing the `data` slice, as well as the overall dimensions of
 ```
 
 To render this virtual data model to a regular HTML `<table>`, all you need to
-do is register this data model via the `setDataModel()` method:
+do is register this data model via the `setDataListener()` method:
 
 ```javascript
-regularTable.setDataModel(getDataSlice);
+regularTable.setDataListener(getDataSlice);
 ```
 
 This will render your regular HTML `<table>` !  Your DOM will look something
@@ -177,45 +177,6 @@ scroll, more data will be fetched from `getDataSlice()`, and parts of the
     </table>
 
 </regular-table>
-```
-
-## `async` Data Models
-
-With an `async` data model, it's easy to serve `getDataSlice()` remotely
-from `node.js` or re-implement the JSON response protocol in any language.
-Just return a `Promise()` from, or use an `async` function as an argument to,
-`setDataModel()`.  Your `<regular-table>` won't render until the
-`Promise` is resolved, nor will it call your data model function again until
-the current call is resolved or rejected.
-
-Here's an `async` example using a Web Worker, but the same principle
-applies to Web Sockets, `readFile()` or any other asynchronous
-source.  Returning a `Promise` blocks rendering until the Web Worker
-replies:
-
-```javascript
-let callback;
-
-worker.addEventListener("message", event => {
-    callback(event.data);
-});
-
-regularTable.setDataModel((...viewport) => {
-    return new Promise(function (resolve) {    
-        callback = resolve;
-        worker.postMessage(viewport);
-    });
-}); 
-```
-
-This example works by calling a simple remote call wrapper to
-`getDataSlice()` in your Web Worker:
-
-```javascript
-self.addEventListener("message", async (event) => {
-    const response = await getDataSlice.apply(null, event.data);
-    self.postMessage(response);
-});
 ```
 
 ## Column and Row Headers
@@ -408,6 +369,45 @@ to one `<th>` node in the resulting `<table>`:
 </regular-table>
 ```
 
+## `async` Data Models
+
+With an `async` data model, it's easy to serve `getDataSlice()` remotely
+from `node.js` or re-implement the JSON response protocol in any language.
+Just return a `Promise()` from, or use an `async` function as an argument to,
+`setDataListener()`.  Your `<regular-table>` won't render until the
+`Promise` is resolved, nor will it call your data model function again until
+the current call is resolved or rejected.
+
+Here's an `async` example using a Web Worker, but the same principle
+applies to Web Sockets, `readFile()` or any other asynchronous
+source.  Returning a `Promise` blocks rendering until the Web Worker
+replies:
+
+```javascript
+let callback;
+
+worker.addEventListener("message", event => {
+    callback(event.data);
+});
+
+regularTable.setDataListener((...viewport) => {
+    return new Promise(function (resolve) {    
+        callback = resolve;
+        worker.postMessage(viewport);
+    });
+}); 
+```
+
+This example works by calling a simple remote call wrapper to
+`getDataSlice()` in your Web Worker:
+
+```javascript
+self.addEventListener("message", async (event) => {
+    const response = await getDataSlice.apply(null, event.data);
+    self.postMessage(response);
+});
+```
+
 ## Development
 
 First install `dev_dependencies`:
@@ -437,4 +437,5 @@ yarn start
 ## Stats
 
 [![Build Status](https://travis-ci.org/jpmorganchase/regular-table.svg?branch=master)](https://travis-ci.org/jpmorganchase/regular-table)
-![npm bundle size](https://img.shields.io/bundlephobia/minzip/regular-table) -->
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/regular-table) 
+-->

--- a/examples/2d_array.html
+++ b/examples/2d_array.html
@@ -44,7 +44,8 @@
         }
 
         const table = document.getElementsByTagName("regular-table")[0];
-        table.setDataModel(getDataSlice);
+        table.setDataListener(getDataSlice);
+        table.draw();
     </script>
 
 </body>

--- a/examples/canvas_data_model.html
+++ b/examples/canvas_data_model.html
@@ -34,13 +34,29 @@
             margin: 0;
             overflow: auto;
         }
-        th:not(:first-child), td {
+        regular-table tbody th {
+            text-align: center;
+        }
+        regular-table tbody th:nth-child(2),
+        regular-table thead tr:first-child th
+        {
+            border-right: 1px solid white;
+        }
+        regular-table thead tr:first-child th {
+            text-align: left;
+            padding-left: 6px;
+        }
+        regular-table thead th:first-child {
+            border-right: 1px solid white;
+        }
+        regular-table th:not(:first-child),
+        regular-table td {
             height: 20px !important;
             min-width: 20px !important;
             max-width: 20px !important;
             padding: 0px;
         }
-        th {           
+        regular-table th {           
             color: white;
             font-family: monospace;
         }
@@ -48,7 +64,6 @@
             vertical-align: top;
             border-bottom: 1px solid white;
             border-right: 0px !important;
-            text-align: left;
         }
         regular-table {
             position: absolute;
@@ -108,7 +123,7 @@
             scroll_container.removeChild(ref_image);
             scroll_container.appendChild(canvas);
         
-            table.addEventListener("regular-table-after-update", () => {
+            table.addStyleListener(() => {
                 const tds = table.querySelectorAll("td");
                 for (const td of tds) {
                     td.style.backgroundColor = td.textContent;
@@ -120,7 +135,7 @@
             const formatter = new Intl.NumberFormat("en-us");
             const clamp = (x, y) => formatter.format(Math.floor(x / y) * y);
         
-            await table.setDataModel((x0, y0, x1, y1) => {
+            table.setDataListener((x0, y0, x1, y1) => {
                 const data = [];
                 for (let i = x0; i < x1; i++) {
                     const column = [];

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -215,8 +215,8 @@
         }
 
         window.addEventListener("DOMContentLoaded", async function () {
-            await TABLE.setDataModel(file_browser_model);
-            TABLE.addEventListener("regular-table-after-update", file_browser_style);
+            TABLE.setDataListener(file_browser_model);
+            TABLE.addStyleListener(file_browser_style);
             TABLE.addEventListener("click", file_browser_on_click);
             await TABLE.draw();
         });

--- a/examples/minesweeper.html
+++ b/examples/minesweeper.html
@@ -32,7 +32,6 @@
             padding: 0 !important;
             font-size: 16px;
         }
-
         regular-table td.unknown {
             background-color: #999;
             border-top: 4px solid #CCC;
@@ -40,18 +39,11 @@
             border-bottom: 4px solid #666;
             border-right: 4px solid #888;
         }
-
-        td.boom {
+        td.boom,td.boom span {
             color: red !important;
             background-color: red !important;
             border: 0px !important;
         }
-
-        td.boom span {
-            color: red !important;
-            background-color: red !important;
-        }
-
         regular-table {
             cursor: pointer;
         }
@@ -102,12 +94,8 @@
             color: black;
             background-color: white;
         }
-        /* .2-marker {
-            color: green;
-        } */
     </style>
 </head>
-
 <body>
 
     <regular-table></regular-table>
@@ -147,7 +135,14 @@
             MINE_DATA[Math.floor(Math.random() * WIDTH)][Math.floor(Math.random() * HEIGHT)] = 9;
         }
 
-        //const COLUMN_NAMES = Array.from(Array(WIDTH).keys());
+        function* neighborIterator(x, y) {
+            for (const [dx, dy] of OFFSETS) {
+                const x2 = x + dx;
+                const y2 = y + dy;
+                if (x2 < 0 || x2 >= WIDTH || y2 < 0 || y2 >= HEIGHT) continue;
+                yield [x2, y2];
+            }
+        }
 
         function clear(candidates) {
             while (candidates.length > 0) {
@@ -155,20 +150,14 @@
                 const [x1, y1] = candidates.pop();
                 if (x1 < 0 || x1 >= WIDTH || y1 < 0 || y1 >= HEIGHT) continue;
 
-                for (const [dx, dy] of OFFSETS) {
-                    const x2 = x1 + dx;
-                    const y2 = y1 + dy;
-                    if (x2 < 0 || x2 >= WIDTH || y2 < 0 || y2 >= HEIGHT) continue;
+                for (const [x2, y2] of neighborIterator(x1, y1)) {
                     if (MINE_DATA[x2][y2] === MINE_ENUM) {
                         count++;
                     }
                 }
                 VIEW_DATA[x1][y1] = count;
                 if (count === 0) {
-                    for (const [dx, dy] of OFFSETS) {
-                        const x2 = x1 + dx;
-                        const y2 = y1 + dy;
-                        if (x2 < 0 || x2 >= WIDTH || y2 < 0 || y2 >= HEIGHT) continue;
+                    for (const [x2, y2] of neighborIterator(x1, y1)) {
                         if (VIEW_DATA[x2][y2] === CLEAR_ENUM) {
                             candidates.push([x2, y2]);
                         }
@@ -203,23 +192,7 @@
             }
         }
 
-        function getDataSlice(x0, y0, x1, y1) {
-            const data = VIEW_DATA.slice(x0, x1).map((col) => col.slice(y0, y1).map(format));
-            //const column_headers = COLUMN_NAMES.slice(x0, x1);
-            const num_columns = VIEW_DATA.length;
-            const num_rows = VIEW_DATA[0].length;
-        
-            return {
-                num_rows,
-                num_columns,
-                //column_headers,
-                data,
-            };
-        }
-
-        const table = document.getElementsByTagName("regular-table")[0];
-
-        table.addEventListener("regular-table-after-update", () => {
+        function styleListener() {
             for (const td of table.get_tds()) {
                 const meta = table.get_meta(td);
                 const val = VIEW_DATA[meta.x][meta.y];
@@ -236,18 +209,28 @@
                     td.classList.toggle("flag", VIEW_DATA[meta.x][meta.y] === FLAG_ENUM);
                 }
             }
-        });
+        }
 
-        table.setDataModel(getDataSlice);
+        function dataListener(x0, y0, x1, y1) {
+            const data = VIEW_DATA.slice(x0, x1).map((col) => col.slice(y0, y1).map(format));
+            const num_columns = VIEW_DATA.length;
+            const num_rows = VIEW_DATA[0].length;
+        
+            return {
+                num_rows,
+                num_columns,
+                data,
+            };
+        }
 
-        table.addEventListener("click", (event) => {
+        function clickEventListener(event) {
             if (event.target.tagName === "TD") {
                 const meta = table.get_meta(event.target);
                 detonate(meta.x, meta.y);
             }
-        });
+        }
 
-        table.addEventListener("contextmenu", (event) => {
+        function contextMenuEventListener(event) {
             event.preventDefault();
             if (event.target.tagName === "TD") {
                 const meta = table.get_meta(event.target);
@@ -255,10 +238,7 @@
                 if (val > CLEAR_ENUM && val < 9) {
                     const candidates = [];
                     let count = 0;
-                    for (const [dx, dy] of OFFSETS) {
-                        const x2 = meta.x + dx;
-                        const y2 = meta.y + dy;
-                        if (x2 < 0 || x2 >= WIDTH || y2 < 0 || y2 >= HEIGHT) continue;
+                    for (const [x2, y2] of neighborIterator(meta.x, meta.y)) {
                         if (VIEW_DATA[x2][y2] !== FLAG_ENUM) {
                             candidates.push([x2, y2]);
                         } else {
@@ -275,9 +255,15 @@
                 }
                 table.draw({invalid_viewport: true});
             }
-        });
+        }
+
+        const table = document.getElementsByTagName("regular-table")[0];
+        table.setDataListener(dataListener);
+        table.addStyleListener(styleListener);
+        table.addEventListener("click", clickEventListener);
+        table.addEventListener("contextmenu", contextMenuEventListener);
+        table.draw();
     </script>
 
 </body>
-
 </html>

--- a/examples/perspective.html
+++ b/examples/perspective.html
@@ -104,8 +104,6 @@
                 }
 
                 return {
-                    __id_column: columns.__ID__,
-                    __schema: this._schema,
                     num_rows: this._num_rows,
                     num_columns: this._column_paths.length,
                     row_headers: (columns.__ROW_PATH__ || []).map((x) => [this._tree_header(x, x.length === 3, true)]),
@@ -130,10 +128,14 @@
                         td.classList.toggle("pd-align-left", false);
                         if (parseFloat(metadata.value) > 0) {
                             td.classList.add("pd-positive");
+                            td.classList.toggle("pd-negative", false);
                         } else if (parseFloat(metadata.value) < 0) {
                             td.classList.add("pd-negative");
+                            td.classList.toggle("pd-positive", false);
                         }
                     } else {
+                        td.classList.toggle("pd-positive", false);
+                        td.classList.toggle("pd-negative", false);
                         td.classList.toggle("pd-align-right", false);
                         td.classList.toggle("pd-align-left", true);
                     }
@@ -158,11 +160,10 @@
     
     <script>
         const URL = "../node_modules/superstore-arrow/superstore.arrow";
-        const perspective = window.perspective;
 
         const datasource = async () => {
             const request = fetch(URL);
-            const worker = perspective.worker();
+            const worker = window.perspective.worker();
             const response = await request;
             const buffer = await response.arrayBuffer();
             return worker.table(buffer);
@@ -176,8 +177,9 @@
             await data_model.set_view(table, view);
 
             const regular = document.getElementsByTagName("regular-table")[0];
-            await regular.addStyleModel(data_model.applyStyle.bind(data_model));
-            await regular.setDataModel(data_model.getData.bind(data_model));
+            regular.addStyleListener(data_model.applyStyle.bind(data_model));
+            regular.setDataListener(data_model.getData.bind(data_model));
+            await regular.draw();
         });
     </script>
 

--- a/examples/perspective_headers.html
+++ b/examples/perspective_headers.html
@@ -104,8 +104,6 @@
                 }
 
                 return {
-                    __id_column: columns.__ID__,
-                    __schema: this._schema,
                     num_rows: this._num_rows,
                     num_columns: this._column_paths.length,
                     row_headers: (columns.__ROW_PATH__ || []).map((x) => [this._tree_header(x, x.length === 3, true)]),
@@ -130,10 +128,14 @@
                         td.classList.toggle("pd-align-left", false);
                         if (parseFloat(metadata.value) > 0) {
                             td.classList.add("pd-positive");
+                            td.classList.toggle("pd-negative", false);
                         } else if (parseFloat(metadata.value) < 0) {
                             td.classList.add("pd-negative");
+                            td.classList.toggle("pd-positive", false);
                         }
                     } else {
+                        td.classList.toggle("pd-positive", false);
+                        td.classList.toggle("pd-negative", false);
                         td.classList.toggle("pd-align-right", false);
                         td.classList.toggle("pd-align-left", true);
                     }
@@ -186,8 +188,9 @@
             await data_model.set_view(table, view);
 
             const regular = document.getElementsByTagName("regular-table")[0];
-            await regular.addStyleModel(data_model.applyStyle.bind(data_model));
-            await regular.setDataModel(data_model.getData.bind(data_model));
+            regular.addStyleListener(data_model.applyStyle.bind(data_model));
+            regular.setDataListener(data_model.getData.bind(data_model));
+            await regular.draw();
         });
     </script>
 

--- a/examples/two_billion_rows.html
+++ b/examples/two_billion_rows.html
@@ -53,7 +53,8 @@
         }
 
         const table = document.getElementsByTagName("regular-table")[0];
-        table.setDataModel(test_data_model);
+        table.setDataListener(test_data_model);
+        table.draw();
     </script>
 
 </body>

--- a/examples/virtual_indices.html
+++ b/examples/virtual_indices.html
@@ -61,7 +61,8 @@
         }
 
         const table = document.getElementsByTagName("regular-table")[0];
-        table.setDataModel(test_data_model);
+        table.setDataListener(test_data_model);
+        table.draw();
     </script>
 
 </body>

--- a/examples/web_worker.html
+++ b/examples/web_worker.html
@@ -71,12 +71,14 @@
             callback(event.data);
         });
 
-        regularTable.setDataModel((...viewport) => {
+        regularTable.setDataListener((...viewport) => {
             return new Promise(function (resolve) {
                 callback = resolve;
                 worker.postMessage(viewport);
             });
         });
+
+        regularTable.draw();
     </script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
     "jsdelivr": "dist/umd/regular-table.js",
     "files": [
         "dist/**/*",
+        "less",
         "babel.config.js"
     ],
     "scripts": {
-        "prebuild": "mkdirp dist/esm dist/css dist/less",
-        "build:static": "cpx \"src/less/*\" dist/less && cpx \"examples/*\" dist/examples",
+        "prebuild": "mkdirp dist/esm dist/css",
         "build:babel": "babel src/js --source-maps --out-dir dist/esm",
         "build:webpack": "webpack --color",
         "build:less": "lessc src/less/material.less dist/css/material.css",
-        "build": "npm-run-all build:static build:babel build:webpack build:less",
+        "build": "npm-run-all build:babel build:webpack build:less",
         "clean": "rimraf dist",
         "lint": "eslint src examples/*.html",
         "fix": "eslint src examples/*.html --fix",

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -6,7 +6,9 @@ const pkg = JSON.parse(fs.readFileSync("package.json").toString());
 const hashes = {
     two_billion_rows: "483a42e7b877043714e18bea6872b039",
     canvas_data_model: "4c6537e23dff3c8f97c316559cef012e",
-    perspective: "d92520387cb7aa5752dad7286cbb89c9",
+    perspective_headers: "d92520387cb7aa5752dad7286cbb89c9",
+    minesweeper: "96a9ed60d0250f7d3187c0fed5f5b78c",
+    file_browser: "a7b7588c899e3953dd8580e81c51b3f9",
 };
 
 for (const file in hashes) {

--- a/src/js/custom_element.js
+++ b/src/js/custom_element.js
@@ -25,6 +25,7 @@ export class RegularViewModel extends RegularViewEventModel {
         this.register_listeners();
         this.setAttribute("tabindex", "0");
         this._column_sizes = {auto: {}, override: {}, indices: []};
+        this._style_callbacks = new Map();
         this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
         if (!this.table_model) return;
         if (this !== this._sticky_container.parentElement) {
@@ -90,11 +91,13 @@ export class RegularViewModel extends RegularViewEventModel {
         this.reset_viewport();
     }
 
-    async addStyleModel(view) {
-        return this.addEventListener("regular-table-after-update", view);
+    addStyleListener(view) {
+        const key = this._style_callbacks.size;
+        this._style_callbacks.set(key, view);
+        return key;
     }
 
-    async setDataModel(view) {
+    setDataListener(view) {
         let schema = {};
         let config = {
             row_pivots: [],
@@ -102,21 +105,6 @@ export class RegularViewModel extends RegularViewEventModel {
         };
 
         this._invalid_schema = true;
-        const options = this.infer_options(config);
         this._view_cache = {view, config, schema};
-        await this.draw(options);
-    }
-
-    save() {
-        const selected = this._get_selected();
-        if (selected !== undefined) {
-            return {selected};
-        }
-    }
-
-    restore(config) {
-        if (config.selected) {
-            this._set_selected(config.selected);
-        }
     }
 }

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -55,7 +55,6 @@ export class RegularHeaderViewModel extends ViewModel {
         }
         const th = this._get_cell("TH", d, cidx);
         if (!th) return;
-        th.setAttribute("colspan", "1");
         return th;
     }
 
@@ -137,6 +136,7 @@ export class RegularHeaderViewModel extends ViewModel {
                     group_meta.vcidx = vcidx;
                     group_meta.size_key = metadata.size_key;
                 }
+                th.removeAttribute("colspan");
             }
             if (colspan > 1) {
                 th.setAttribute("colspan", colspan);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -126,38 +126,6 @@ const invertPromise = () => {
     return promise;
 };
 
-export function isEqual(a, b) {
-    if (a === b) return true;
-    if (a && b && typeof a == "object" && typeof b == "object") {
-        if (a.constructor !== b.constructor) return false;
-        let length, i, keys;
-        if (Array.isArray(a)) {
-            length = a.length;
-            if (length != b.length) return false;
-            for (i = length; i-- !== 0; ) if (!isEqual(a[i], b[i])) return false;
-            return true;
-        }
-
-        if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-        if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
-        keys = Object.keys(a);
-        length = keys.length;
-        if (length !== Object.keys(b).length) return false;
-        for (i = length; i-- !== 0; ) {
-            if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
-        }
-
-        for (i = length; i-- !== 0; ) {
-            let key = keys[i];
-            if (!isEqual(a[key], b[key])) return false;
-        }
-
-        return true;
-    }
-
-    return a !== a && b !== b;
-}
-
 export function throttlePromise(target, property, descriptor) {
     const lock = Symbol("private lock");
     const f = descriptor.value;


### PR DESCRIPTION
This PR fixes many small style and CSS bugs, as well as clarifies some API methods:

* `setDataModel()` is now `setDataListener()`
* `addEventListener('regular-table-after-updates')` is now `addStyleListener()`, which will help prepare for `async` support on these callbacks.