### PR TITLE
Add benchmark.html and `getDrawFPS()`

### DIFF
--- a/examples/benchmark.html
+++ b/examples/benchmark.html
@@ -1,0 +1,108 @@
+<!--
+   
+   Copyright (c) 2020, the Regular Table Authors.
+   
+   This file is part of the Regular Table library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <script src="../dist/umd/regular-table.js"></script>
+    <link rel='stylesheet' href="../dist/css/material.css">
+
+    <style>
+        td {
+            color: #1078d1;
+        }
+
+        #fps {
+            border: 1px solid #CCC;
+            position: absolute;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            bottom: 0;
+            right: 0;
+            padding: 12px;
+            margin: 12px;
+            font-family: "Roboto Mono";
+            font-size: 16px;
+            text-align: center;
+            vertical-align: middle;
+            background-color: white;
+        }
+    </style>
+</head>
+
+<body>
+
+    <regular-table></regular-table>
+
+    <div id="fps"></div>
+
+    <script>
+        const NUM_ROWS = 10000;
+        const NUM_COLUMNS = 1000;
+
+        const formatter = new Intl.NumberFormat("en-us");
+
+        const clamp = (x, y, offset = 0) => Math.floor(x / y) * y + offset + "";
+
+        async function test_data_model(x0, y0, x1, y1) {
+            const data = [];
+            const column_headers = [];
+            for (let i = x0; i < x1; i++) {
+                const column = [];
+                data.push(column);
+                column_headers.push([`Group ${clamp(i, 10)}`, `Column ${i}`]);
+                for (let j = y0; j < y1; j++) {
+                    column.push(formatter.format(j + i));
+                }
+            }
+
+            const row_headers = [];
+            for (let j = y0; j < y1; j++) {
+                row_headers.push(["Group " + clamp(j, 10, 0), "Row " + j]);
+            }
+
+            return {
+                num_rows: NUM_ROWS,
+                num_columns: NUM_COLUMNS,
+                row_headers,
+                column_headers,
+                data,
+            };
+        }
+
+        const table = document.getElementsByTagName("regular-table")[0];
+        table.setDataListener(test_data_model);
+        table.draw();
+
+        // Update FPS indicator
+        setInterval(() => {
+            const fps = table.getDrawFPS().real_fps.toFixed(2);
+            window.fps.textContent = `${fps} fps`;
+        }, 1000);
+
+        // Trigger diagonal scroll events in a loop forever.
+        (function run() {
+            table.scrollTop += 20;
+            table.scrollLeft += 10;
+            if (table.scrollLeft === table.scrollWidth - table.offsetWidth) {
+                table.scrollLeft = 0;
+            }
+            if (table.scrollTop === table.scrollHeight - table.offsetHeight) {
+                table.scrollTop = 0;
+            }
+            setTimeout(run);
+        })();
+    </script>
+
+</body>
+
+</html>

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -13,7 +13,7 @@
 export const METADATA_MAP = new WeakMap();
 
 // Output runtime debug info like FPS.
-export const DEBUG = false;
+export const DEBUG = true;
 
 // Double buffer when the viewport scrolls columns, rows or when the
 // view is recreated.  Reduces render draw-in on some browsers, at the

--- a/src/js/custom_element.js
+++ b/src/js/custom_element.js
@@ -11,6 +11,7 @@
 import {METADATA_MAP} from "./constants";
 import {RegularTableViewModel} from "./table";
 import {RegularViewEventModel} from "./events";
+import {get_draw_fps} from "./utils";
 
 /**
  * Regular's "public" API.  See the `superstore-custom-grid.html` simple
@@ -91,9 +92,31 @@ export class RegularViewModel extends RegularViewEventModel {
         this.reset_viewport();
     }
 
-    addStyleListener(view) {
+    /**
+     * Get performance statistics about this `<regular-table>`.  Calling this
+     * method resets the internal state, which makes it convenient to measure
+     * performance at regular intervals (see example).
+     * @returns {*} An object with performance statistics about calls to
+     * `draw()`, with the following keys:
+     * * `avg` - Avergage milliseconds per call
+     * * `real_fps` - `num_frames` / `elapsed`
+     * * `virtual_fps` - `elapsed` / `avg`
+     * * `num_frames` - Number of frames rendered
+     * * `elapsed` - Number of milliseconds since last call to `getDrawFPS()`
+     * @example
+     * const table = document.getElementById("my_regular_table");
+     * setInterval(() => {
+     *     const {real_fps} = table.getDrawFPS();
+     *     console.log(`Measured ${fps} fps`)
+     * });
+     */
+    getDrawFPS() {
+        return get_draw_fps();
+    }
+
+    addStyleListener(styleListener) {
         const key = this._style_callbacks.size;
-        this._style_callbacks.set(key, view);
+        this._style_callbacks.set(key, styleListener);
         return key;
     }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,7 +8,6 @@
  *
  */
 
-import {_start_profiling_loop} from "./utils";
 import {RegularViewModel} from "./custom_element";
 
 /******************************************************************************
@@ -18,5 +17,3 @@ import {RegularViewModel} from "./custom_element";
  */
 
 window.customElements.define("regular-table", RegularViewModel);
-
-_start_profiling_loop();

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -8,8 +8,6 @@
  *
  */
 
-import {DEBUG} from "./constants";
-
 /******************************************************************************
  *
  * Events
@@ -57,25 +55,26 @@ export async function getCellConfig({view, config}, row_idx, col_idx) {
  *
  */
 
-let LOG = [];
+let AVG = 0,
+    TOTAL = 0,
+    START = performance.now();
 
-function log_fps() {
-    const avg = LOG.reduce((x, y) => x + y, 0) / LOG.length;
-    const rfps = LOG.length / 5;
-    const vfps = 1000 / avg;
-    const nframes = LOG.length;
-    console.log(`${avg.toFixed(2)} ms/frame   ${rfps} rfps   ${vfps.toFixed(2)} vfps   (${nframes} frames in 5s)`);
-    LOG = [];
+export function get_draw_fps() {
+    const now = performance.now();
+    const elapsed = now - START;
+    const avg = AVG;
+    const real_fps = (TOTAL * 1000) / elapsed;
+    const virtual_fps = 1000 / avg;
+    const num_frames = TOTAL;
+    AVG = 0;
+    TOTAL = 0;
+    START = now;
+    return {avg, real_fps, virtual_fps, num_frames, elapsed};
 }
 
 export function log_perf(x) {
-    LOG.push(x);
-}
-
-export function _start_profiling_loop() {
-    if (DEBUG) {
-        setInterval(log_fps, 5000);
-    }
+    AVG = (AVG * TOTAL + x) / (TOTAL + 1);
+    TOTAL += 1;
 }
 
 /******************************************************************************


### PR DESCRIPTION
* Refactors log-based performance monitoring to `getDrawFPS()` method, which returns stats collected since last invocation.
* Adds `benchmark.html`, which scrolls as fast as `setInterval()` allows and logs FPS to a toaster popup,  to glorify feature.