### PR TITLE
`spreadsheet.html` Example

### DIFF
--- a/examples/canvas_data_model.html
+++ b/examples/canvas_data_model.html
@@ -37,7 +37,7 @@
         regular-table tbody th {
             text-align: center;
         }
-        regular-table tbody th:nth-child(2),
+        regular-table tbody th:last-of-type,
         regular-table thead tr:first-child th
         {
             border-right: 1px solid white;
@@ -60,10 +60,10 @@
             color: white;
             font-family: monospace;
         }
-        tbody th:first-child {
+        tbody th[rowspan] {
             vertical-align: top;
             border-bottom: 1px solid white;
-            border-right: 0px !important;
+            /* border-right: 0px !important; */
         }
         regular-table {
             position: absolute;

--- a/examples/perspective_headers.html
+++ b/examples/perspective_headers.html
@@ -39,12 +39,6 @@
             min-width: 40px;
         }
 
-
-        regular-table tbody th:last-of-type {
-            max-width: 100px;
-            min-width: 100px;
-        }
-
     </style>
 </head>
 

--- a/examples/spreadsheet.html
+++ b/examples/spreadsheet.html
@@ -1,0 +1,167 @@
+<!--
+   
+   Copyright (c) 2020, the Regular Table Authors.
+   
+   This file is part of the Regular Table library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <script src="../dist/umd/regular-table.js"></script>
+    <link rel='stylesheet' href="../dist/css/material.css">
+    <style>
+        td {
+            outline: none;
+            border-right: 1px solid #eee;
+            border-bottom: 1px solid #eee;
+            min-width: 22px;
+        }
+        tbody th {
+            border-right: 1px solid #eee;
+        }
+    </style>
+</head>
+
+<body>
+
+    <regular-table></regular-table>
+
+    <script>
+        // Data Model
+        window.DATA = Array.from(Array(78).fill()).map(() => Array(100).fill());
+
+        window.DATA_COLUMN_NAMES = (() => {
+            const caps = Array.from(Array(26)).map((val, i) => String.fromCharCode(i + 65));
+            return caps.concat(
+                caps.map((letter) => letter + letter),
+                caps.map((letter) => letter + letter + letter)
+            );
+        })();
+
+        window.dataListener = function dataListener(x0, y0, x1, y1) {
+            return {
+                num_rows: window.DATA[0].length,
+                num_columns: window.DATA.length,
+                row_headers: Array.from(Array(Math.ceil(y1) - y0).keys()).map((y) => [`${y + y0}`]),
+                column_headers: window.DATA_COLUMN_NAMES.slice(x0, x1).map((x) => [x]),
+                data: window.DATA.slice(x0, x1).map((col) => col.slice(y0, y1)),
+            };
+        };
+    </script>
+
+    <script>
+        // Expression Evaluator
+        function col2Idx(x) {
+            return window.DATA_COLUMN_NAMES.indexOf(x);
+        }
+
+        window.flat = function flat(arr) {
+            return arr
+                .flat(1)
+                .map(parseInt)
+                .filter((x) => !isNaN(x));
+        };
+
+        window.sum = function sum(arr) {
+            return window.flat(arr).reduce((x, y) => parseInt(x) + parseInt(y));
+        };
+
+        window.avg = function avg(arr) {
+            const x = window.flat(arr);
+            return x.reduce((x, y) => parseInt(x) + parseInt(y)) / x.length;
+        };
+
+        window.slice = function (x0, y0, x1, y1) {
+            return window.DATA.slice(x0, parseInt(x1) + 1).map((z) => z.slice(y0, parseInt(y1) + 1));
+        };
+
+        window.stringify = function (x, y) {
+            let txt = window.DATA[x][y];
+            let num = parseInt(txt);
+            if (isNaN(num)) {
+                num = txt;
+            }
+            return `${num}`;
+        };
+
+        const RANGE_PATTERN = /([A-Z]+)([0-9]+)\.\.([A-Z]+)([0-9]+)/g;
+        const CELL_PATTERN = /([A-Z]+)([0-9]+)/g;
+
+        window.compile = function compile(input) {
+            const output = input
+                .slice(1)
+                .replace(RANGE_PATTERN, (_, x0, y0, x1, y1) => {
+                    return `slice(${col2Idx(x0)}, ${y0}, ${col2Idx(x1)}, ${y1})`;
+                })
+                .replace(CELL_PATTERN, (_, x, y) => {
+                    return `stringify(${col2Idx(x)}, ${y})`;
+                });
+        
+            console.log(`Compiled '${input}' to '${output}'`);
+            return eval(output);
+        };
+    </script>
+
+    <script>
+        // regular-table UI
+        const table = document.getElementsByTagName("regular-table")[0];
+
+        function write(active_cell) {
+            const meta = table.get_meta(active_cell);
+            if (meta) {
+                let text = active_cell.textContent;
+                if (text[0] === "=") {
+                    text = window.compile(text);
+                }
+                window.DATA[meta.x][meta.y] = text;
+                active_cell.blur();
+                table.draw({invalid_viewport: true});
+            }
+        }
+
+        function increment(active_cell) {
+            const meta = table.get_meta(active_cell);
+            const rows = Array.from(table.querySelectorAll("tbody tr"));
+            const next_row = rows[meta.ridx + 1];
+            if (next_row) {
+                const td = next_row.children[meta.cidx];
+                td.focus();
+            }
+        }
+
+        table.setDataListener(window.dataListener);
+
+        table.addStyleListener(() => {
+            for (const td of table.get_tds()) {
+                td.setAttribute("contenteditable", true);
+            }
+        });
+
+        table.addEventListener("scroll", () => {
+            write(document.activeElement);
+        });
+
+        table.addEventListener("keypress", (event) => {
+            if (event.keyCode === 13) {
+                event.preventDefault();
+                const target = document.activeElement;
+                write(target);
+                increment(target);
+            }
+        });
+
+        table.addEventListener("focusout", (event) => {
+            write(event.target);
+        });
+
+        table.draw();
+    </script>
+
+</body>
+
+</html>

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -197,7 +197,9 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     _max_scroll_column(num_columns) {
         let width = 0;
         if (this._view_cache.config.row_pivots.length > 0) {
-            width = this._column_sizes.indices[0];
+            for (const w of this._column_sizes.indices.slice(0, this._view_cache.config.row_pivots.length)) {
+                width += w;
+            }
         }
         let max_scroll_column = num_columns;
         while (width < this._container_size.width && max_scroll_column >= 0) {

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -19,11 +19,11 @@ console.assert(["none", "rowspan", "rowspan_hide", "rowspan_leading"].indexOf(RO
  * @class RegularBodyViewModel
  */
 export class RegularBodyViewModel extends ViewModel {
-    _draw_td(tagName, ridx, val, id, cidx, {column_name}, {ridx_offset, cidx_offset}) {
+    _draw_td(tagName, ridx, val, id, cidx, {column_name}, {ridx_offset}) {
         const td = this._get_cell(tagName, ridx, cidx);
         const metadata = this._get_or_create_metadata(td);
         metadata.id = id;
-        metadata.cidx = cidx + cidx_offset;
+        metadata.ridx = ridx;
         metadata.column = column_name;
         metadata.y = ridx + ridx_offset;
         const override_width = this._column_sizes.override[metadata.size_key];
@@ -72,7 +72,7 @@ export class RegularBodyViewModel extends ViewModel {
         return prev_i;
     }
 
-    draw(container_height, column_state, view_state, th = false, dcidx) {
+    draw(container_height, column_state, view_state, th = false, dcidx, cidx_offset, size_key) {
         const {cidx, column_data, id_column} = column_state;
         let {row_height} = view_state;
         let ridx = 0;
@@ -99,7 +99,7 @@ export class RegularBodyViewModel extends ViewModel {
                     }
                     if (obj) {
                         obj.metadata.row_header_x = i;
-                        obj.metadata.size_key = `R${i}`;
+                        obj.metadata.size_key = i;
                     }
                     cidx_++;
                 }
@@ -108,7 +108,9 @@ export class RegularBodyViewModel extends ViewModel {
             } else {
                 obj = this._draw_td("TD", ridx++, val, id, cidx, column_state, view_state);
                 obj.metadata.x = dcidx;
-                obj.metadata.size_key = dcidx + "";
+                obj.metadata.x0 = cidx_offset;
+                obj.metadata.size_key = size_key;
+                obj.metadata.cidx = cidx;
                 prev = [[val, obj, 1]];
             }
 

--- a/test/spreadsheet.test.js
+++ b/test/spreadsheet.test.js
@@ -1,0 +1,113 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2020, the Regular Table Authors.
+ *
+ * This file is part of the Regular Table library, distributed under the terms
+ * of the Apache License 2.0.  The full license can be found in the LICENSE
+ * file.
+ *
+ */
+
+describe("spreadsheet.html", () => {
+    beforeAll(async () => {
+        await page.setViewport({width: 100, height: 100});
+    });
+
+    describe("Makes a simple edit", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/spreadsheet.html");
+            await page.waitFor("regular-table table tbody tr td");
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                const cell = table.querySelector("table tbody").children[2].children[1];
+                cell.textContent = "Hello, World!";
+                cell.focus();
+                const event = document.createEvent("HTMLEvents");
+                event.initEvent("keypress", false, true);
+                event.ctrlKey = true;
+                event.keyCode = 13;
+                table.dispatchEvent(event);
+            }, table);
+        });
+
+        test("displays input", async () => {
+            const first_tr = await page.$$("regular-table tbody td");
+            const cell_values = [];
+            for (const tr of first_tr) {
+                cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
+            }
+            expect(cell_values).toEqual(["", "", "Hello, World!", "", ""]);
+        });
+
+        describe("on scroll", () => {
+            beforeAll(async () => {
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTop = table.scrollTop + 20;
+                    await table.draw();
+                }, table);
+            });
+
+            test("preserves input", async () => {
+                const first_tr = await page.$$("regular-table tbody td");
+                const cell_values = [];
+                for (const tr of first_tr) {
+                    cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
+                }
+                expect(cell_values).toEqual(["", "Hello, World!", "", "", ""]);
+            });
+        });
+    });
+
+    describe("Evaluates an expression", () => {
+        beforeAll(async () => {
+            await page.goto("http://localhost:8081/examples/spreadsheet.html");
+            await page.waitFor("regular-table table tbody tr td");
+            const table = await page.$("regular-table");
+            await page.evaluate(async (table) => {
+                for (const [x, y, v] of [
+                    [2, 1, "1"],
+                    [3, 1, "2"],
+                    [3, 2, "=sum(A0..A3)"],
+                ]) {
+                    const cell = table.querySelector("table tbody").children[x].children[y];
+                    cell.textContent = v;
+                    cell.focus();
+                    const event = document.createEvent("HTMLEvents");
+                    event.initEvent("keypress", false, true);
+                    event.ctrlKey = true;
+                    event.keyCode = 13;
+                    table.dispatchEvent(event);
+                }
+            }, table);
+        });
+
+        test("displays evaluated expression", async () => {
+            const first_tr = await page.$$("regular-table tbody td");
+            const cell_values = [];
+            for (const tr of first_tr) {
+                cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
+            }
+            expect(cell_values).toEqual(["", "", "", "", "", "", "1", "", "", "2", "3", "", "", "", ""]);
+        });
+
+        describe("on scroll", () => {
+            beforeAll(async () => {
+                const table = await page.$("regular-table");
+                await page.evaluate(async (table) => {
+                    table.scrollTop = table.scrollTop + 20;
+                    await table.draw();
+                }, table);
+            });
+
+            test("preserves evaluated expression", async () => {
+                const first_tr = await page.$$("regular-table tbody td");
+                const cell_values = [];
+                for (const tr of first_tr) {
+                    cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
+                }
+                expect(cell_values).toEqual(["", "", "", "1", "", "", "2", "3", "", "", "", "", "", "", ""]);
+            });
+        });
+    });
+});

--- a/test/two_billion_rows/metadata.test.js
+++ b/test/two_billion_rows/metadata.test.js
@@ -24,10 +24,12 @@ describe("two_billion_rows.html Metadata", () => {
             expect(JSON.parse(meta)).toEqual({
                 cidx: 0,
                 column: ["Column 0"],
-                x: 0,
-                y: 0,
-                size_key: "0",
+                ridx: 0,
+                size_key: 0,
                 value: "0",
+                x: 0,
+                x0: 0,
+                y: 0,
             });
         });
 
@@ -47,12 +49,14 @@ describe("two_billion_rows.html Metadata", () => {
                     return JSON.stringify(table.get_meta(document.querySelector("td")));
                 }, table);
                 expect(JSON.parse(meta)).toEqual({
-                    cidx: 16,
+                    cidx: 0,
                     column: ["Column 16"],
-                    x: 16,
-                    y: 0,
-                    size_key: "16",
+                    ridx: 0,
+                    size_key: 16,
                     value: "16",
+                    x: 16,
+                    x0: 16,
+                    y: 0,
                 });
             });
         });
@@ -75,10 +79,12 @@ describe("two_billion_rows.html Metadata", () => {
                 expect(JSON.parse(meta)).toEqual({
                     cidx: 0,
                     column: ["Column 0"],
-                    x: 0,
-                    y: 200002,
-                    size_key: "0",
+                    ridx: 0,
+                    size_key: 0,
                     value: "200,002",
+                    x: 0,
+                    x0: 0,
+                    y: 200002,
                 });
             });
         });


### PR DESCRIPTION
A `<td>` within a `<table>` has a number of interesting metadata values which this PR now calculates more-correctly:

* `size_key` - a unique column ID (including row header `<th>` columns.
* `cidx` - the index within the current `<tr>`.
* `x` and `y` - the corresponding indices into the `data` property returned by the data model.

Also adds a motivating example which requires precise data spatial awareness, `spreadsheet.html`, which uses `contenteditable` to implement a simple Excel-style app complete with an expression language with range syntax support:

![spreadsheet](https://user-images.githubusercontent.com/60666/83595293-94664e00-a52f-11ea-8520-0b851df75609.gif)
