### PR TITLE
Adds LICENSE and README info to example gists

### DIFF
--- a/examples/canvas_data_model.html
+++ b/examples/canvas_data_model.html
@@ -7,6 +7,14 @@
 
 -->
 
+<!--
+
+    An example of using a `<canvas>` element as a data model for [`regular-table`](https://github.com/jpmorganchase/regular-table).
+    As you `mouseover` the image, a cursor tooltip `<regular-table>` shows a
+    zoom-in via a virtual data model which defers to [`context.getImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData).
+
+-->
+
 <!DOCTYPE html>
 <html>
 

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -7,6 +7,12 @@
 
 -->
 
+<!--
+
+    A simple file browser example built with [`regular-table`](https://github.com/jpmorganchase/regular-table).
+
+-->
+
 <!DOCTYPE html>
 <html>
 

--- a/examples/minesweeper.html
+++ b/examples/minesweeper.html
@@ -7,6 +7,15 @@
 
 -->
 
+<!--
+
+    A clone of the classic game Minesweeper with 1,000,000 cells, built with
+    [`regular-table`](https://github.com/jpmorganchase/regular-table).  
+    
+-->
+    
+-->
+
 <!DOCTYPE html>
 <html>
 

--- a/examples/perspective_headers.html
+++ b/examples/perspective_headers.html
@@ -7,6 +7,13 @@
 
 -->
 
+<!--
+
+    An example of a multi-dimensional pivot table using [`regular-table`](https://github.com/jpmorganchase/regular-table)
+    and [`perspective`](https://perspective.finos.org/). 
+    
+-->
+
 <!DOCTYPE html>
 <html>
 

--- a/examples/spreadsheet.html
+++ b/examples/spreadsheet.html
@@ -7,6 +7,15 @@
 
 -->
 
+<!--
+
+    A simple spreadsheet-like app which demonstrates use of [`regular-table`](https://github.com/jpmorganchase/regular-table).
+    Supports a simple expression language for cells starting with a `=`
+    character, such as `=sum(A2..C4)` for the sum of cell values within the
+    rectangular region (A2, C4).
+    
+-->
+
 <!DOCTYPE html>
 <html>
 
@@ -63,7 +72,7 @@
         window.flat = function flat(arr) {
             return arr
                 .flat(1)
-                .map(parseInt)
+                .map((x) => parseInt(x))
                 .filter((x) => !isNaN(x));
         };
 

--- a/examples/two_billion_rows.html
+++ b/examples/two_billion_rows.html
@@ -7,6 +7,14 @@
 
 -->
 
+<!--
+
+    An example of a [`regular-table`](https://github.com/jpmorganchase/regular-table)
+    data model which generates data on-the-fly to simulate a 2,000,000,000 row
+    `<table>`.
+    
+-->
+
 <!DOCTYPE html>
 <html>
 


### PR DESCRIPTION
Adds transform to `sync_gist` script which extracts the license header, as well as the following HTML comment block which it uses to generate a `README.md`.  Such `README` descriptions have been added to the example gallery.

Also generates a `.block` header for repos which lack one explicitly.

Fixes #30 