### PR TITLE
Fixes regular-table in firefox; fixups for scrollbar styling

### DIFF
--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -402,6 +402,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this._invalid_schema = false;
         }
 
+        // polyfill `overflow: overlay` by adding scrollbar dims to table_clip
+        this._table_clip.style.height = `calc(100% + ${this.offsetHeight - this.clientHeight}px)`;
+        this._table_clip.style.width = `calc(100% + ${this.offsetWidth - this.clientWidth}px)`;
+
         if (DEBUG) {
             log_perf(performance.now() - __debug_start_time__);
         }

--- a/src/less/container.less
+++ b/src/less/container.less
@@ -14,34 +14,32 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
-    overflow: overlay;
-    -webkit-overflow-scrolling: auto;
+    overflow: auto;
 }
 
 div.pd-virtual-panel {
-    position:absolute;
-    top:0;
-    left:0;
-    right:0;
-    pointer-events:none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    pointer-events: none;
 }
 
 div.pd-scroll-table-clip {
-    position:sticky;
-    position:-webkit-sticky;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 div.pd-tree-container {
-    display:flex;
-    align-items:center;
-    height:100%;
+    display: flex;
+    align-items: center;
+    height: 100%;
 }
 
 slot {
-    position:absolute;
-    overflow:hidden;
+    position: absolute;
+    overflow: hidden;
 }

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -16,6 +16,14 @@
 
 regular-table {
     padding: 12px;
+
+    // firefox scrollbar styling
+    scrollbar-color: transparent transparent;
+    scrollbar-width: thin;
+}
+
+regular-table:hover {
+    scrollbar-color: rgba(0,0,0,0.3) transparent;
 }
 
 regular-table, :host {
@@ -31,7 +39,7 @@ regular-table, :host {
         left: 0;
         right: 0;
         bottom: 0;
-        overflow: hidden;    
+        overflow: hidden;
     }
 
     th {
@@ -174,7 +182,7 @@ regular-table, :host {
         flex: 1;
         height: 100%;
     }
-    
+
     th span.pd-group-name {
         text-align: left;
     }
@@ -193,21 +201,32 @@ regular-table, :host {
         cursor: col-resize;
     }
 
-    &::-webkit-scrollbar {
-        width: 8px;
-        height: 8px;
+    // webkit (chrome, safari, etc) scrollbar styling
+
+    &::-webkit-scrollbar,
+    &::-webkit-scrollbar-corner {
+        background-color: transparent;
+        height: 12px;
+        width: 12px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-clip: content-box;
+        background-color: rgba(0,0,0,0);
+        border-radius: 5px;
+    }
+
+    &::-webkit-scrollbar-thumb:horizontal {
+        border-bottom: 2px solid transparent;
+        border-top: 2px solid transparent;
+    }
+
+    &::-webkit-scrollbar-thumb:vertical {
+        border-left: 2px solid transparent;
+        border-right: 2px solid transparent;
     }
 
     &:hover::-webkit-scrollbar-thumb {
         background-color: rgba(0,0,0,0.3);
-    }
-
-    &::-webkit-scrollbar-thumb {
-        border-radius: 4px;
-        background-color: rgba(0,0,0,0);
-    }
-
-    &::-webkit-scrollbar-corner {
-        background-color: rgba(0,0,0,0);
     }
 }


### PR DESCRIPTION
Fixes #26

Some of our styling was webkit-only, which was breaking our examples etc in firefox:

https://github.com/jpmorganchase/regular-table/blob/f60a572904ee753624f9516182ff23a6562d0562/src/less/container.less#L11-L19

Firefox doesn't know what to do with `overflow: overlay`. Although a regular-table was still scrollable in firefox, the actual `"scroll"` events were not being emitted, and so the table was never updated/redrawn.

This PR:

- replaces `overflow: overlay` with `overflow: auto` in the .less
- recreates the same behavior as `overflow: overlay` on the javascript side
- fixes up the rest of the styling to match these changes
- adds styling for scrollbars in firefox (roughly) equivalent to the existing webkit scrollbar styling

Visually, the only change this PR makes in chrome is that each scrollbar thumb is now centered in its track.

before this PR:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/2263641/83985684-2394ac80-a908-11ea-8a01-10dc0bb46115.png">

after this PR:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/2263641/83985675-17a8ea80-a908-11ea-92f5-e9adff042ac4.png">

