### PR TITLE
Fixes example regression and adds a test

### DIFF
--- a/examples/spreadsheet.html
+++ b/examples/spreadsheet.html
@@ -136,9 +136,9 @@
         function increment(active_cell) {
             const meta = table.getMeta(active_cell);
             const rows = Array.from(table.querySelectorAll("tbody tr"));
-            const next_row = rows[meta.ridx + 1];
+            const next_row = rows[meta.y - meta.y0 + 1];
             if (next_row) {
-                const td = next_row.children[meta.cidx];
+                const td = next_row.children[meta.x + 1];
                 td.focus();
             }
         }

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -39,6 +39,11 @@ describe("spreadsheet.html", () => {
             expect(cell_values).toEqual(["", "", "Hello, World!", "", ""]);
         });
 
+        test("next cell has focus", async () => {
+            const contents = await page.evaluate(() => document.activeElement.textContent);
+            expect(contents).toEqual("");
+        });
+
         describe("on scroll", () => {
             beforeAll(async () => {
                 const table = await page.$("regular-table");


### PR DESCRIPTION
Fixes a regression in `spreadsheet.html`, which relied on deprecated `Metadata` properties.  Also adds a test for the affected functionality.