### PR TITLE
Fix sticky column resize behavior

### DIFF
--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -367,15 +367,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this.reset_scroll();
         }
 
-        const {num_columns, num_rows, __config, __schema} = await this._view_cache.view(0, 0, 0, 0);
-
-        if (__config) {
-            this._view_cache.config = __config;
-        }
-
-        if (__schema) {
-            this._view_cache.schema = __schema;
-        }
+        const {num_columns, num_rows} = await this._view_cache.view(0, 0, 0, 0);
 
         if (this._virtual_scrolling_disabled) {
             this._container_size = {width: Infinity, height: Infinity};

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -111,9 +111,7 @@ export class RegularTableViewModel {
             }
             first_col = false;
             view_state.viewport_width +=
-                // TODO correctly memoize this value
-                //this._column_sizes.indices.sli ||
-                cont_body.tds.reduce((total, {td}) => total + td.offsetWidth, 0) || cont_heads.reduce((total, {th}) => total + th.offsetWidth, 0);
+                cont_body.tds.reduce((total, {td}, i) => total + (this._column_sizes.indices[i] || td.offsetWidth), 0) || cont_heads.reduce((total, {th}) => total + th.offsetWidth, 0);
             view_state.row_height = view_state.row_height || cont_body.row_height;
             _virtual_x = row_headers[0].length;
             if (!preserve_width) {

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -19,10 +19,11 @@ console.assert(["none", "rowspan", "rowspan_hide", "rowspan_leading"].indexOf(RO
  * @class RegularBodyViewModel
  */
 export class RegularBodyViewModel extends ViewModel {
-    _draw_td(tagName, ridx, val, cidx, {column_name}, {ridx_offset}) {
+    _draw_td(tagName, ridx, val, cidx, {column_name}, {ridx_offset}, size_key) {
         const td = this._get_cell(tagName, ridx, cidx);
         const metadata = this._get_or_create_metadata(td);
         metadata.y = ridx + ridx_offset;
+        metadata.size_key = size_key;
         if (tagName === "TD") {
             metadata.column_header = column_name;
         }
@@ -94,12 +95,11 @@ export class RegularBodyViewModel extends ViewModel {
                     if (prev && prev[i][0] === row_header) {
                         row.push(this._merge_th(trailing, prev[i], i, ridx, row_header, cidx_, column_state, view_state));
                     } else {
-                        obj = this._draw_td("TH", ridx, row_header, cidx_, column_state, view_state);
+                        obj = this._draw_td("TH", ridx, row_header, cidx_, column_state, view_state, i);
                         obj.td.style.display = "";
                         obj.td.removeAttribute("rowspan");
                         obj.metadata.row_header = val;
                         obj.metadata.row_header_x = i;
-                        obj.metadata.size_key = i;
                         obj.metadata.x0 = x0;
                         obj.metadata.y0 = view_state.ridx_offset;
                         obj.metadata._virtual_x = i;
@@ -110,14 +110,13 @@ export class RegularBodyViewModel extends ViewModel {
                 prev = row;
                 ridx++;
             } else {
-                obj = this._draw_td("TD", ridx++, val, cidx, column_state, view_state);
+                obj = this._draw_td("TD", ridx++, val, cidx, column_state, view_state, size_key);
                 obj.metadata.x = x;
                 obj.metadata.x0 = x0;
                 obj.metadata.row_header = id || {test: 2};
                 obj.metadata.y0 = view_state.ridx_offset;
                 obj.metadata.dx = x - x0;
                 obj.metadata.dy = obj.metadata.y - obj.metadata.y0;
-                obj.metadata.size_key = size_key;
                 obj.metadata._virtual_x = _virtual_x;
                 prev = [[val, obj, 1]];
             }

--- a/test/examples/two_billion_rows.test.js
+++ b/test/examples/two_billion_rows.test.js
@@ -57,7 +57,7 @@ describe("two_billion_rows.html", () => {
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["Group 200,000", "Row 200,002", "200,002"]);
+            expect(cell_values).toEqual(["Group 200,000", "Row 200,002", "200,002", "200,003"]);
         });
     });
 
@@ -121,7 +121,7 @@ describe("two_billion_rows.html", () => {
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["Group 1,999,999,990", "Row 1,999,999,998", "1,999,999,998"]);
+            expect(cell_values).toEqual(["Group 1,999,999,990", "Row 1,999,999,998", "1,999,999,998", "1,999,999,999"]);
         });
     });
 


### PR DESCRIPTION
Fixes a bug in column resize behavior which caused `override` column widths to apply to the wrong columns when scrolling horizontally.