### PR TITLE
Firefox fix

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -24,4 +24,5 @@ export const DOUBLE_BUFFER_RECREATE = false;
 
 // The largest size virtual <div> in (px) that Chrome can support without
 // glitching.
-export const BROWSER_MAX_HEIGHT = 10000000;
+const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+export const BROWSER_MAX_HEIGHT = isFirefox ? 5000000 : 10000000;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -54,9 +54,9 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         }
         event.preventDefault();
         event.returnValue = false;
-        const {offsetWidth, offsetHeight, scrollTop, scrollLeft} = this;
-        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - offsetHeight);
-        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - offsetWidth);
+        const {clientWidth, clientHeight, scrollTop, scrollLeft} = this;
+        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - clientHeight);
+        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - clientWidth);
         this.scrollTop = Math.min(total_scroll_height, scrollTop + event.deltaY);
         this.scrollLeft = Math.min(total_scroll_width, scrollLeft + event.deltaX);
         this._on_scroll(event);

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -394,6 +394,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this._invalid_schema = false;
         }
 
+        // polyfill `overflow: overlay` by adding scrollbar dims to table_clip
+        this._table_clip.style.height = `calc(100% + ${this.offsetHeight - this.clientHeight}px)`;
+        this._table_clip.style.width = `calc(100% + ${this.offsetWidth - this.clientWidth}px)`;
+
         if (DEBUG) {
             log_perf(performance.now() - __debug_start_time__);
         }

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -144,13 +144,14 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         const {height} = this._container_size;
         const row_height = this._column_sizes.row_height || 19;
         const header_levels = this._view_cache.config.column_pivots.length + 1;
-        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this.offsetHeight);
+        // TODO use cached height?
+        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this.clientHeight);
         const percent_scroll = this.scrollTop / total_scroll_height;
         const virtual_panel_row_height = height / row_height;
         const relative_nrows = !reset_scroll_position ? this._nrows || 0 : nrows;
         const scroll_rows = Math.max(0, relative_nrows + (header_levels - virtual_panel_row_height));
         let start_row = Math.ceil(scroll_rows * percent_scroll);
-        let end_row = Math.ceil(start_row + virtual_panel_row_height + 1);
+        let end_row = Math.min(Math.ceil(start_row + virtual_panel_row_height), nrows);
         return {start_row, end_row};
     }
 
@@ -316,7 +317,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     scrollTo(x, y, ncols, nrows) {
         const row_height = this._virtual_panel.offsetHeight / nrows;
         this.scrollTop = row_height * y;
-        this.scrollLeft = (x / (this._max_scroll_column() || ncols)) * (this.scrollWidth - this.offsetWidth);
+        // TODO use cached?
+        this.scrollLeft = (x / (this._max_scroll_column() || ncols)) * (this.scrollWidth - this.clientWidth);
     }
 
     /**
@@ -332,8 +334,9 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         if (this._virtual_scrolling_disabled) {
             virtual_panel_px_size = nrows * row_height + header_height;
         } else {
-            const {height} = this._container_size;
-            const zoom_factor = this.offsetHeight / (height - header_height);
+            //const {height} = this._container_size;
+            // TODO use cached height?
+            const zoom_factor = this.clientHeight / (this._table_clip.offsetHeight - header_height);
             virtual_panel_px_size = Math.min(BROWSER_MAX_HEIGHT, nrows * row_height * zoom_factor);
         }
         this._virtual_panel.style.height = `${virtual_panel_px_size}px`;
@@ -373,8 +376,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this._container_size = {width: Infinity, height: Infinity};
         } else {
             this._container_size = (!this._invalid_schema && !invalid_viewport && this._container_size) || {
-                width: this._table_clip.offsetWidth,
-                height: this._table_clip.offsetHeight,
+                width: this._table_clip.clientWidth,
+                height: this._table_clip.clientHeight,
             };
         }
 

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -394,10 +394,6 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this._invalid_schema = false;
         }
 
-        // polyfill `overflow: overlay` by adding scrollbar dims to table_clip
-        this._table_clip.style.height = `calc(100% + ${this.offsetHeight - this.clientHeight}px)`;
-        this._table_clip.style.width = `calc(100% + ${this.offsetWidth - this.clientWidth}px)`;
-
         if (DEBUG) {
             log_perf(performance.now() - __debug_start_time__);
         }

--- a/src/less/container.less
+++ b/src/less/container.less
@@ -14,7 +14,7 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
-    overflow: auto;
+    overflow: scroll;
 }
 
 div.pd-virtual-panel {

--- a/src/less/container.less
+++ b/src/less/container.less
@@ -14,34 +14,32 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
-    overflow: overlay;
-    -webkit-overflow-scrolling: auto;
+    overflow: auto;
 }
 
 div.pd-virtual-panel {
-    position:absolute;
-    top:0;
-    left:0;
-    right:0;
-    pointer-events:none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    pointer-events: none;
 }
 
 div.pd-scroll-table-clip {
-    position:sticky;
-    position:-webkit-sticky;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }
 
 div.pd-tree-container {
-    display:flex;
-    align-items:center;
-    height:100%;
+    display: flex;
+    align-items: center;
+    height: 100%;
 }
 
 slot {
-    position:absolute;
-    overflow:hidden;
+    position: absolute;
+    overflow: hidden;
 }

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -15,7 +15,10 @@
 @row-height: 19px;
 
 regular-table {
-    padding: 12px;
+    padding-top: 12px;
+    padding-left: 12px;
+    padding-bottom: 0;
+    padding-right: 0;
 
     // firefox scrollbar styling
     scrollbar-color: transparent transparent;

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -16,6 +16,14 @@
 
 regular-table {
     padding: 12px;
+
+    // firefox scrollbar styling
+    scrollbar-color: transparent transparent;
+    scrollbar-width: thin;
+}
+
+regular-table:hover {
+    scrollbar-color: rgba(0,0,0,0.3) transparent;
 }
 
 regular-table, :host {
@@ -31,7 +39,7 @@ regular-table, :host {
         left: 0;
         right: 0;
         bottom: 0;
-        overflow: hidden;    
+        overflow: hidden;
     }
 
     th {
@@ -174,7 +182,7 @@ regular-table, :host {
         flex: 1;
         height: 100%;
     }
-    
+
     th span.pd-group-name {
         text-align: left;
     }
@@ -193,21 +201,32 @@ regular-table, :host {
         cursor: col-resize;
     }
 
-    &::-webkit-scrollbar {
-        width: 8px;
-        height: 8px;
+    // webkit (chrome, safari, etc) scrollbar styling
+
+    &::-webkit-scrollbar,
+    &::-webkit-scrollbar-corner {
+        background-color: transparent;
+        height: 12px;
+        width: 12px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-clip: content-box;
+        background-color: rgba(0,0,0,0);
+        border-radius: 5px;
+    }
+
+    &::-webkit-scrollbar-thumb:horizontal {
+        border-bottom: 2px solid transparent;
+        border-top: 2px solid transparent;
+    }
+
+    &::-webkit-scrollbar-thumb:vertical {
+        border-left: 2px solid transparent;
+        border-right: 2px solid transparent;
     }
 
     &:hover::-webkit-scrollbar-thumb {
         background-color: rgba(0,0,0,0.3);
-    }
-
-    &::-webkit-scrollbar-thumb {
-        border-radius: 4px;
-        background-color: rgba(0,0,0,0);
-    }
-
-    &::-webkit-scrollbar-corner {
-        background-color: rgba(0,0,0,0);
     }
 }

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -93,7 +93,7 @@ describe("spreadsheet.html", () => {
             for (const tr of first_tr) {
                 cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
             }
-            expect(cell_values).toEqual(["", "", "", "", "", "", "1", "", "", "2", "3", "", "", "", ""]);
+            expect(cell_values).toEqual(["", "", "", "", "", "", "", "", "1", "", "", "", "2", "3", "", "", "", "", "", ""]);
         });
 
         describe("on scroll", () => {
@@ -111,7 +111,7 @@ describe("spreadsheet.html", () => {
                 for (const tr of first_tr) {
                     cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
                 }
-                expect(cell_values).toEqual(["", "", "", "1", "", "", "2", "3", "", "", "", "", "", "", ""]);
+                expect(cell_values).toEqual(["", "", "", "", "1", "", "", "", "2", "3", "", "", "", "", "", "", "", "", "", ""]);
             });
         });
     });

--- a/test/examples/two_billion_rows.test.js
+++ b/test/examples/two_billion_rows.test.js
@@ -115,7 +115,7 @@ describe("two_billion_rows.html", () => {
         test("with the correct # of rows", async () => {
             const tbody = await page.$("regular-table tbody");
             const num_rows = await page.evaluate((tbody) => tbody.children.length, tbody);
-            expect(num_rows).toEqual(5);
+            expect(num_rows).toEqual(2);
         });
 
         test("with the first row's cell test correct", async () => {

--- a/test/examples/web_worker.test.js
+++ b/test/examples/web_worker.test.js
@@ -10,7 +10,7 @@
 
 describe("web_worker.html", () => {
     beforeAll(async () => {
-        await page.setViewport({width: 200, height: 100});
+        await page.setViewport({width: 250, height: 100});
     });
 
     // TODO don't run these, they depend on unpkg.com
@@ -29,7 +29,7 @@ describe("web_worker.html", () => {
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["0", "1", "2"]);
+            expect(cell_values).toEqual(["0", "1", "2", "3"]);
         });
     });
 
@@ -47,7 +47,7 @@ describe("web_worker.html", () => {
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["200,002", "200,003", "200,004"]);
+            expect(cell_values).toEqual(["200,002", "200,003", "200,004", "200,005"]);
         });
     });
 });

--- a/test/features/getMeta.test.js
+++ b/test/features/getMeta.test.js
@@ -147,16 +147,16 @@ describe("getMeta()", () => {
                 }, table);
                 expect(JSON.parse(meta)).toEqual({
                     column_header: ["Group 0", "Column 0"],
-                    row_header: ["Group 30", "Row 37"],
+                    row_header: ["Group 40", "Row 40"],
                     dx: 0,
                     dy: 0,
                     size_key: 2,
                     _virtual_x: 2,
-                    value: "37",
+                    value: "40",
                     x: 0,
                     x0: 0,
-                    y: 37,
-                    y0: 37,
+                    y: 40,
+                    y0: 40,
                 });
             });
 
@@ -166,13 +166,13 @@ describe("getMeta()", () => {
                     return JSON.stringify(table.getMeta(document.querySelector("tbody th")));
                 }, table);
                 expect(JSON.parse(meta)).toEqual({
-                    row_header: ["Group 30", "Row 37"],
+                    row_header: ["Group 40", "Row 40"],
                     size_key: 0,
                     _virtual_x: 0,
-                    value: "Group 30",
+                    value: "Group 40",
                     row_header_x: 0,
-                    y: 37,
-                    y0: 37,
+                    y: 40,
+                    y0: 40,
                 });
             });
 

--- a/test/features/scrolling.test.js
+++ b/test/features/scrolling.test.js
@@ -10,7 +10,7 @@
 
 describe("scrolling", () => {
     beforeAll(async () => {
-        await page.setViewport({width: 250, height: 200});
+        await page.setViewport({width: 260, height: 200});
     });
 
     describe("scrolls down", () => {
@@ -33,13 +33,13 @@ describe("scrolling", () => {
         test("with the correct # of columns", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const num_cells = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
-            expect(num_cells).toEqual(4);
+            expect(num_cells).toEqual(5);
         });
 
         test("with the first row's <td> test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.querySelectorAll("td")).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["37", "38"]);
+            expect(cell_values).toEqual(["40", "41", "42"]);
         });
     });
 


### PR DESCRIPTION
Rebased and amended version of #36.

* The main fix alters regular-table virtual position calculations to use `clientWidth` and `clientHeight` over `offsetWidth`, `offsetHeight`, where appropriate, to handle non-zero-width scrollbars.
* Removes style code which was hard to `material` theme.
* Hardcodes non-overlay scrollbars to the material theme, since it is more important this theme be
consistent.
