### PR TITLE
Add x1, y1 to getMeta()

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -229,7 +229,13 @@ window.customElements.define("regular-table", RegularTableElement);
  * your data model, e.g. what was passed to `x0` when your
  * `dataListener` was invoked.
  * @property {number} [y0] - The `y` index of the viewport origin in
- * your data model, e.g. what was passed to `x0` when your
+ * your data model, e.g. what was passed to `y0` when your
+ * `dataListener` was invoked.
+ * @property {number} [x1] - The `x` index of the viewport corner in
+ * your data model, e.g. what was passed to `x1` when your
+ * `dataListener` was invoked.
+ * @property {number} [y1] - The `y` index of the viewport origin in
+ * your data model, e.g. what was passed to `y1` when your
  * `dataListener` was invoked.
  * @property {number} [dx] - The `x` index in `DataResponse.data`, this
  * property is only generated for `<td>`, and `<th>` from `column_headers`.

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -68,7 +68,7 @@ export class RegularTableViewModel {
         const {width: container_width, height: container_height} = container_size;
         const {view, config} = view_cache;
         let {data, row_headers, column_headers} = await view(viewport.start_col, viewport.start_row, viewport.end_col, viewport.end_row);
-        const {start_row: ridx_offset = 0, start_col: x0 = 0} = viewport;
+        const {start_row: ridx_offset = 0, start_col: x0 = 0, end_col: x1 = 0, end_row: y1 = 0} = viewport;
 
         // pad row_headers for embedded renderer
         // TODO maybe dont need this - perspective compat
@@ -88,6 +88,8 @@ export class RegularTableViewModel {
             selected_id,
             ridx_offset,
             x0: x0,
+            x1: x1,
+            y1: y1,
             row_height: this._column_sizes.row_height,
             row_headers_length: this._row_headers_length,
         };

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -89,6 +89,7 @@ export class RegularBodyViewModel extends ViewModel {
                         obj.metadata.row_header_x = i;
                         obj.metadata.x0 = x0;
                         obj.metadata.y0 = view_state.ridx_offset;
+                        obj.metadata.y1 = view_state.y1;
                         obj.metadata._virtual_x = i;
                         ridx_offset[i] = 1;
                         cidx_offset[ridx] = 1;
@@ -99,8 +100,10 @@ export class RegularBodyViewModel extends ViewModel {
                     obj = this._draw_td("TD", ridx++, val, cidx, column_state, view_state, size_key);
                     obj.metadata.x = x;
                     obj.metadata.x0 = x0;
+                    obj.metadata.x1 = view_state.x1;
                     obj.metadata.row_header = id || {test: 2};
                     obj.metadata.y0 = view_state.ridx_offset;
+                    obj.metadata.y1 = view_state.y1;
                     obj.metadata.dx = x - x0;
                     obj.metadata.dy = obj.metadata.y - obj.metadata.y0;
                     obj.metadata._virtual_x = _virtual_x;

--- a/test/features/getMeta.test.js
+++ b/test/features/getMeta.test.js
@@ -21,6 +21,7 @@ describe("getMeta()", () => {
             const meta = await page.evaluate((table) => {
                 return JSON.stringify(table.getMeta(document.querySelector("td")));
             }, table);
+
             expect(JSON.parse(meta)).toEqual({
                 column_header: ["Group 0", "Column 0"],
                 row_header: ["Group 0", "Row 0"],
@@ -31,8 +32,10 @@ describe("getMeta()", () => {
                 value: "0",
                 x: 0,
                 x0: 0,
+                x1: 5,
                 y: 0,
                 y0: 0,
+                y1: 10,
             });
         });
 
@@ -49,6 +52,7 @@ describe("getMeta()", () => {
                 row_header_x: 0,
                 y: 0,
                 y0: 0,
+                y1: 10,
             });
         });
 
@@ -92,8 +96,10 @@ describe("getMeta()", () => {
                     value: "16",
                     x: 16,
                     x0: 16,
+                    x1: 21,
                     y: 0,
                     y0: 0,
+                    y1: 10,
                 });
             });
 
@@ -110,6 +116,7 @@ describe("getMeta()", () => {
                     row_header_x: 0,
                     y: 0,
                     y0: 0,
+                    y1: 10,
                 });
             });
 
@@ -155,8 +162,10 @@ describe("getMeta()", () => {
                     value: "40",
                     x: 0,
                     x0: 0,
+                    x1: 5,
                     y: 40,
                     y0: 40,
+                    y1: 50,
                 });
             });
 
@@ -173,6 +182,7 @@ describe("getMeta()", () => {
                     row_header_x: 0,
                     y: 40,
                     y0: 40,
+                    y1: 50,
                 });
             });
 


### PR DESCRIPTION
This PR exposes the `x1` and `y1` passed to the `DataListener` when invoked via `MetaData`. 