### PR TITLE
Adds manually written index.d.ts typescript type declaration

### DIFF
--- a/examples/canvas_data_model.html
+++ b/examples/canvas_data_model.html
@@ -1,7 +1,7 @@
 <!--
-   
+
    Copyright (c) 2020, the Regular Table Authors.
-   
+
    This file is part of the Regular Table library, distributed under the terms of
    the Apache License 2.0.  The full license can be found in the LICENSE file.
 
@@ -64,7 +64,7 @@
             max-width: 20px !important;
             padding: 0px;
         }
-        regular-table th {           
+        regular-table th {
             color: white;
             font-family: monospace;
         }
@@ -130,7 +130,7 @@
             context.drawImage(ref_image, 0, 0, ref_image.width, ref_image.height);
             scroll_container.removeChild(ref_image);
             scroll_container.appendChild(canvas);
-        
+
             table.addStyleListener(() => {
                 const tds = table.querySelectorAll("td");
                 for (const td of tds) {
@@ -142,7 +142,7 @@
             const column_names = Array.from(Array(canvas.width).keys());
             const formatter = new Intl.NumberFormat("en-us");
             const clamp = (x, y) => formatter.format(Math.floor(x / y) * y);
-        
+
             table.setDataListener((x0, y0, x1, y1) => {
                 const data = [];
                 for (let i = x0; i < x1; i++) {
@@ -188,7 +188,7 @@
                 table.style.top = `${Math.min(top_scroll_limit, y + 20)}px`;
                 table.style.left = `${Math.min(left_scroll_limit, x + 20)}px`;
             }
-            table.scrollTo(x, y, canvas.width, canvas.height);
+            table.scrollToCell(x, y, canvas.width, canvas.height);
         });
     </script>
 

--- a/examples/file_browser.md
+++ b/examples/file_browser.md
@@ -28,14 +28,14 @@ groups of rows via `row_headers`, for example a file structure like so:
 
 ```json
 [
-    ["Dir_1"], 
+    ["Dir_1"],
     ["Dir_1", "Dir_2"],
     ["Dir_1", "Dir_2", "File_1"],
     ["Dir_1", "File_2"]
 ]
 ```
 
-This will render _group-like_ row headers, with the consecutive `"Dir_1"` and 
+This will render _group-like_ row headers, with the consecutive `"Dir_1"` and
 `"Dir_2"` elements merged via `rowspan`.  The resulting headers visually
 indicate all content on the right-hand side belong to the directory.   This is
 exactly what column headers do, but it is not very like a file-tree; each
@@ -57,7 +57,7 @@ can instead replace the consecutive duplicates with `""`.
 
 ```json
 [
-    ["Dir_1"], 
+    ["Dir_1"],
     ["", "Dir_2"],
     ["", "", "File_1"],
     ["", "File_2"]
@@ -92,7 +92,7 @@ function new_path(n, name) {
 }
 ```
 
-## File System 
+## File System
 
 We can use a regular 2D Array, row oriented, for the file system listing state
 itself, including file metadata like `size` and the open/closed state of
@@ -211,7 +211,7 @@ function styleListener() {
 ## UI
 
 When directory rows are clicked, generate new directory contents at the `td`
-metadata's `y` coordinate in `DATA` and redraw.  
+metadata's `y` coordinate in `DATA` and redraw.
 
 ```javascript
 // TODO `resetAutoSize()` is not documented - this is currently required to
@@ -240,7 +240,7 @@ function init() {
     regularTable.addStyleListener(styleListener);
     regularTable.addEventListener("mousedown", mousedownListener);
     regularTable.addEventListener("scroll", () => {
-        regularTable.resetAutoSize();
+        regularTable._resetAutoSize();
     });
     regularTable.draw();
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,287 @@
+declare module 'regular-table' {
+    // only need the @types/react pkg for this, not the runtime react pkg
+    import { DetailedHTMLProps, HTMLAttributes } from "react";
+
+    /**
+     * The `<regular-table>` custom element.
+     *
+     * This module has no exports, but importing it has a side effect: the
+     * `RegularTableElement` class is registered as a custom element, after which
+     * it can be used as a standard DOM element.
+     *
+     * The documentation in this module defines the instance structure of a
+     * `<regular-table>` DOM object instantiated typically, through HTML or any
+     * relevent DOM method e.g. `document.createElement("perspective-viewer")` or
+     * `document.getElementsByTagName("perspective-viewer")`.
+     *
+     * @public
+     * @extends HTMLElement
+     */
+    export class RegularTableElement extends HTMLElement {
+        /**
+         * Adds a style listener callback. The style listeners are called
+         * whenever the <table> is re-rendered, such as through API invocations
+         * of draw() and user-initiated events such as scrolling. Within this
+         * optionally async callback, you can select <td>, <th>, etc. elements
+         * via regular DOM API methods like querySelectorAll().
+         *
+         * @public
+         * @memberof RegularTableElement
+         * @param {function({detail: RegularTableElement}): void} styleListener - A
+         * (possibly async) function that styles the inner <table>.
+         * @returns {number} The index of the added listener.
+         * @example
+         * table.addStyleListener(() => {
+         *     for (const td of table.querySelectorAll("td")) {
+         *         td.setAttribute("contenteditable", true);
+         *     }
+         * });
+         */
+        addStyleListener(styleListener: (arg0: {
+                detail: RegularTableElement;
+        }) => void): number;
+
+        /**
+         * Returns the `MetaData` object associated with a `<td>` or `<th>`.  When
+         * your `StyleListener` is invoked, use this method to look up additional
+         * `MetaData` about any `HTMLTableCellElement` in the rendered `<table>`.
+         *
+         * @public
+         * @memberof RegularTableElement
+         * @param {HTMLTableCellElement|Partial<MetaData>} element - The child element
+         * of this `<regular-table>` for which to look up metadata, or a
+         * coordinates-like object to refer to metadata by logical position.
+         * @returns {MetaData} The metadata associated with the element.
+         * @example
+         * const elems = document.querySelector("td:last-child td:last_child");
+         * const metadata = table.getMeta(elems);
+         * console.log(`Viewport corner is ${metadata.x}, ${metadata.y}`);
+         * @example
+         * const header = table.getMeta({row_header_x: 1, y: 3}).row_header;
+         */
+        getMeta(element: HTMLTableCellElement | Partial<MetaData>): MetaData;
+
+        /**
+         * Get performance statistics about this `<regular-table>`.  Calling this
+         * method resets the internal state, which makes it convenient to measure
+         * performance at regular intervals (see example).
+         *
+         * @public
+         * @memberof RegularTableElement
+         * @returns {Performance} Performance data aggregated since the last
+         * call to `getDrawFPS()`.
+         * @example
+         * const table = document.getElementById("my_regular_table");
+         * setInterval(() => {
+         *     const {real_fps} = table.getDrawFPS();
+         *     console.log(`Measured ${fps} fps`)
+         * });
+         */
+        getDrawFPS(): Performance;
+
+
+        // TODO: Deal with scrollTo typescript error. Issue due to fact that
+        // scrollTo shadows base HTMLElement.scrollTo method
+        //
+        // /**
+        //  * Call this method to set the `scrollLeft` and `scrollTop` for this
+        //  * `<regular-table>` by calculating the position of this `scrollLeft`
+        //  * and `scrollTop` relative to the underlying widths of its columns
+        //  * and heights of its rows.
+        //  *
+        //  * @public
+        //  * @memberof RegularTableElement
+        //  * @param {number} x - The left most `x` index column to scroll into view.
+        //  * @param {number} y - The top most `y` index row to scroll into view.
+        //  * @param {number} ncols - Total number of columns in the data model.
+        //  * @param {number} nrows - Total number of rows in the data model.
+        //  * @example
+        //  * table.scrollTo(1, 3, 10, 30);
+        //  */
+        // scrollTo(x: number, y: number, ncols: number, nrows: number): void;
+
+        /**
+         * Call this method to set `DataListener` for this `<regular-table>`,
+         * which will be called whenever a new data slice is needed to render.
+         * Calls to `draw()` will fail if no `DataListener` has been set
+         *
+         * @public
+         * @memberof RegularTableElement
+         * @param {DataListener} dataListener
+         * `dataListener` is called by to request a rectangular section of data
+         * for a virtual viewport, (x0, y0, x1, y1), and returns a `DataReponse`
+         * object.
+         * @example
+         * table.setDataListener((x0, y0, x1, y1) => {
+         *     return {
+         *         num_rows: num_rows = DATA[0].length,
+         *         num_columns: DATA.length,
+         *         data: DATA.slice(x0, x1).map(col => col.slice(y0, y1))
+         *     };
+         * })
+         */
+        setDataListener(dataListener: DataListener): void;
+    }
+
+    /**
+    * An object with performance statistics about calls to
+    * `draw()` from some time interval (captured in milliseconds by the
+    * `elapsed` proprty).
+    */
+    export type Performance = {
+        /**
+         * - Avergage milliseconds per call.
+         */
+        avg: number;
+        /**
+         * - `num_frames` / `elapsed`
+         */
+        real_fps: number;
+        /**
+         * - `elapsed` / `avg`
+         */
+        virtual_fps: number;
+        /**
+         * - Number of frames rendered.
+         */
+        num_frames: number;
+        /**
+         * - Number of milliseconds since last call
+         * to `getDrawFPS()`.
+         */
+        elapsed: number;
+    };
+
+    /**
+    * An object describing virtual rendering metadata about an
+    * `HTMLTableCellElement`, use this object to map rendered `<th>` or `<td>`
+    * elements back to your `data`, `row_headers` or `column_headers` within
+    * listener functions for `addStyleListener()` and `addEventListener()`.
+    */
+    export type MetaData = {
+        /**
+         * - The `x` index in your virtual data model.
+         * property is only generated for `<td>`, `<th>` from `row_headers`.
+         */
+        x?: number;
+        /**
+         * - The `y` index in your virtual data model.
+         * property is only generated for `<td>`, `<th>` from `row_headers`.
+         */
+        y?: number;
+        /**
+         * - The `x` index of the viewport origin in
+         * your data model, e.g. what was passed to `x0` when your
+         * `dataListener` was invoked.
+         */
+        x0?: number;
+        /**
+         * - The `y` index of the viewport origin in
+         * your data model, e.g. what was passed to `x0` when your
+         * `dataListener` was invoked.
+         */
+        y0?: number;
+        /**
+         * - The `x` index in `DataResponse.data`, this
+         * property is only generated for `<td>`, and `<th>` from `column_headers`.
+         */
+        dx?: number;
+        /**
+         * - The `y` index in `DataResponse.data`, this
+         * property is only generated for `<td>`, `<th>` from `row_headers`.
+         */
+        dy?: number;
+        /**
+         * - The `y` index in
+         * `DataResponse.column_headers[x]`, this property is only generated for `<th>`
+         * from `column_headers`.
+         */
+        column_header_y?: number;
+        /**
+         * - The `x` index in
+         * `DataResponse.row_headers[y]`, this property is only generated for `<th>`
+         * from `row_headers`.
+         */
+        column_header_x?: number;
+        /**
+         * - The unique index of this column in a full
+         * `<table>`, which is `x` + (Total Row Header Columns).
+         */
+        size_key: number;
+        /**
+         * - The `Array` for this `y` in
+         * `DataResponse.row_headers`, if it was provided.
+         */
+        row_header?: Array<object>;
+        /**
+         * - The `Array` for this `x` in
+         * `DataResponse.column_headers`, if it was provided.
+         */
+        column_header?: Array<object>;
+    };
+
+    /**
+    * The `DataResponse` object describes a rectangular region of a virtual
+    * data set, and some associated metadata.  `<regular-table>` will use this
+    * object to render the `<table>`, though it may make multiple requests for
+    * different regions to achieve a compelte render as it must estimate
+    * certain dimensions.  You must construct a `DataResponse` object to
+    * implement a `DataListener`.
+    */
+    export type DataResponse = {
+        /**
+         * - A two dimensional
+         * `Array` of column group headers, in specificity order.  No `<thead>`
+         * will be generated if this property is not provided.
+         */
+        column_headers?: Array<Array<object>>;
+        /**
+         * - A two dimensional
+         * `Array` of row group headers, in specificity order.  No `<th>`
+         * elements within `<tbody>` will be generated if this property is not
+         * provided.
+         */
+        row_headers?: Array<Array<object>>;
+        /**
+         * - A two dimensional `Array`
+         * representing a rectangular section of the underlying data set from
+         * (x0, y0) to (x1, y1), arranged in columnar fashion such that
+         * `data[x][y]` returns the `y`th row of the `x`th column of the slice.
+         */
+        data: Array<Array<object>>;
+        /**
+         * - Total number of rows in the underlying
+         * data set.
+         */
+        num_rows: number;
+        /**
+         * - Total number of columns in the
+         * underlying data set.
+         */
+        num_columns: number;
+    };
+
+    /**
+    * The `DataListener` is similar to a normal event listener function.
+    * Unlike a normal event listener, it takes regular arguments (not an
+    * `Event`); and returns a `Promise` for a `DataResponse` object for this
+    * region (as opposed to returning `void` as a standard event listener).
+    */
+    export type DataListener = Function;
+
+    global {
+        namespace JSX {
+            interface IntrinsicElements {
+                "regular-table": DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            }
+        }
+
+        interface Document {
+            createElement(tagName: "regular-table", options?: ElementCreationOptions): RegularTableElement;
+        }
+
+        interface CustomElementRegistry {
+            get(name: 'regular-table'): typeof RegularTableElement;
+        }
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,26 +79,22 @@ declare module 'regular-table' {
          */
         getDrawFPS(): Performance;
 
-
-        // TODO: Deal with scrollTo typescript error. Issue due to fact that
-        // scrollTo shadows base HTMLElement.scrollTo method
-        //
-        // /**
-        //  * Call this method to set the `scrollLeft` and `scrollTop` for this
-        //  * `<regular-table>` by calculating the position of this `scrollLeft`
-        //  * and `scrollTop` relative to the underlying widths of its columns
-        //  * and heights of its rows.
-        //  *
-        //  * @public
-        //  * @memberof RegularTableElement
-        //  * @param {number} x - The left most `x` index column to scroll into view.
-        //  * @param {number} y - The top most `y` index row to scroll into view.
-        //  * @param {number} ncols - Total number of columns in the data model.
-        //  * @param {number} nrows - Total number of rows in the data model.
-        //  * @example
-        //  * table.scrollTo(1, 3, 10, 30);
-        //  */
-        // scrollTo(x: number, y: number, ncols: number, nrows: number): void;
+        /**
+         * Call this method to set the `scrollLeft` and `scrollTop` for this
+         * `<regular-table>` by calculating the position of this `scrollLeft`
+         * and `scrollTop` relative to the underlying widths of its columns
+         * and heights of its rows.
+         *
+         * @public
+         * @memberof RegularTableElement
+         * @param {number} x - The left most `x` index column to scroll into view.
+         * @param {number} y - The top most `y` index row to scroll into view.
+         * @param {number} ncols - Total number of columns in the data model.
+         * @param {number} nrows - Total number of rows in the data model.
+         * @example
+         * table.scrollToCell(1, 3, 10, 30);
+         */
+        scrollToCell(x: number, y: number, ncols: number, nrows: number): void;
 
         /**
          * Call this method to set `DataListener` for this `<regular-table>`,

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "browser": "dist/umd/regular-table.js",
     "unpkg": "dist/umd/regular-table.js",
     "jsdelivr": "dist/umd/regular-table.js",
+    "types": "index.d.ts",
     "files": [
         "dist/css/*.css",
         "dist/umd/*",
         "src/less/*.less",
-        "babel.config.js"
+        "babel.config.js",
+        "index.d.ts"
     ],
     "scripts": {
         "build:examples": "literally -c literally.config.js",
@@ -46,6 +48,7 @@
         "@babel/preset-env": "^7.9.0",
         "@finos/perspective": "=0.5.0",
         "@rollup/plugin-babel": "^5.0.2",
+        "@types/react": "^16.9.38",
         "babel-eslint": "^10.1.0",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-transform-custom-element-classes": "^0.1.0",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -194,9 +194,9 @@ class RegularTableElement extends RegularViewEventModel {
      * @param {number} ncols - Total number of columns in the data model.
      * @param {number} nrows - Total number of rows in the data model.
      * @example
-     * table.scrollTo(1, 3, 10, 30);
+     * table.scrollToCell(1, 3, 10, 30);
      */
-    scrollTo(x, y, ncols, nrows) {
+    scrollToCell(x, y, ncols, nrows) {
         const row_height = this._virtual_panel.offsetHeight / nrows;
         this.scrollTop = row_height * y;
         this.scrollLeft = (x / (this._max_scroll_column(ncols) || ncols)) * (this.scrollWidth - this.clientWidth);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,9 +25,19 @@ import {get_draw_fps} from "./utils";
  * relevent DOM method e.g. `document.createElement("perspective-viewer")` or
  * `document.getElementsByTagName("perspective-viewer")`.
  *
+ * @public
  * @extends HTMLElement
  */
 class RegularTableElement extends RegularViewEventModel {
+    /**
+     * For internal use by the Custom Elements API: "Invoked each time the
+     * custom element is appended into a document-connected element".
+     * Ref: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks
+     *
+     * @internal
+     * @private
+     * @memberof RegularTableElement
+     */
     connectedCallback() {
         this.create_shadow_dom();
         this.register_listeners();
@@ -41,6 +51,13 @@ class RegularTableElement extends RegularViewEventModel {
         }
     }
 
+    /**
+     * Reset the viewport of this regular table.
+     *
+     * @internal
+     * @private
+     * @memberof RegularTableElement
+     */
     _reset_viewport() {
         this._start_row = undefined;
         this._end_row = undefined;
@@ -48,6 +65,13 @@ class RegularTableElement extends RegularViewEventModel {
         this._end_col = undefined;
     }
 
+    /**
+     * Reset the scroll position of this regular table back to the origin.
+     *
+     * @internal
+     * @private
+     * @memberof RegularTableElement
+     */
     _reset_scroll() {
         this._column_sizes.indices = [];
         this.scrollTop = 0;
@@ -55,6 +79,14 @@ class RegularTableElement extends RegularViewEventModel {
         this._reset_viewport();
     }
 
+    /**
+     * Reset column autosizing, such that column sizes will be recalculated
+     * on the next draw() call.
+     *
+     * @internal
+     * @private
+     * @memberof RegularTableElement
+     */
     _resetAutoSize() {
         this._column_sizes.auto = {};
         this._column_sizes.override = {};
@@ -66,6 +98,25 @@ class RegularTableElement extends RegularViewEventModel {
         }
     }
 
+    /**
+     * Adds a style listener callback. The style listeners are called
+     * whenever the <table> is re-rendered, such as through API invocations
+     * of draw() and user-initiated events such as scrolling. Within this
+     * optionally async callback, you can select <td>, <th>, etc. elements
+     * via regular DOM API methods like querySelectorAll().
+     *
+     * @public
+     * @memberof RegularTableElement
+     * @param {function({detail: RegularTableElement}): void} styleListener - A
+     * (possibly async) function that styles the inner <table>.
+     * @returns {number} The index of the added listener.
+     * @example
+     * table.addStyleListener(() => {
+     *     for (const td of table.querySelectorAll("td")) {
+     *         td.setAttribute("contenteditable", true);
+     *     }
+     * });
+     */
     addStyleListener(styleListener) {
         const key = this._style_callbacks.size;
         this._style_callbacks.set(key, styleListener);
@@ -77,7 +128,9 @@ class RegularTableElement extends RegularViewEventModel {
      * your `StyleListener` is invoked, use this method to look up additional
      * `MetaData` about any `HTMLTableCellElement` in the rendered `<table>`.
      *
-     * @param {HTMLTableCellElement|MetaData} element - The child element
+     * @public
+     * @memberof RegularTableElement
+     * @param {HTMLTableCellElement|Partial<MetaData>} element - The child element
      * of this `<regular-table>` for which to look up metadata, or a
      * coordinates-like object to refer to metadata by logical position.
      * @returns {MetaData} The metadata associated with the element.
@@ -113,6 +166,7 @@ class RegularTableElement extends RegularViewEventModel {
      * method resets the internal state, which makes it convenient to measure
      * performance at regular intervals (see example).
      *
+     * @public
      * @memberof RegularTableElement
      * @returns {Performance} Performance data aggregated since the last
      * call to `getDrawFPS()`.
@@ -132,6 +186,8 @@ class RegularTableElement extends RegularViewEventModel {
      * `<regular-table>` by calculating the position of this `scrollLeft`
      * and `scrollTop` relative to the underlying widths of its columns
      * and heights of its rows.
+     *
+     * @public
      * @memberof RegularTableElement
      * @param {number} x - The left most `x` index column to scroll into view.
      * @param {number} y - The top most `y` index row to scroll into view.
@@ -151,6 +207,7 @@ class RegularTableElement extends RegularViewEventModel {
      * which will be called whenever a new data slice is needed to render.
      * Calls to `draw()` will fail if no `DataListener` has been set
      *
+     * @public
      * @memberof RegularTableElement
      * @param {DataListener} dataListener
      * `dataListener` is called by to request a rectangular section of data

--- a/test/examples/2d_array.test.js
+++ b/test/examples/2d_array.test.js
@@ -38,7 +38,7 @@ describe("2d_array.html", () => {
         });
     });
 
-    describe("scrolls via scrollTo() method", () => {
+    describe("scrolls via scrollToCell() method", () => {
         beforeAll(async () => {
             await page.goto("http://localhost:8081/dist/examples/2d_array.html");
             await page.waitFor("regular-table table tbody tr td");
@@ -48,7 +48,7 @@ describe("2d_array.html", () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
                 table._invalid_schema = true;
-                table.scrollTo(0, 1, 3, 26);
+                table.scrollToCell(0, 1, 3, 26);
                 await table.draw({invalid_viewport: true});
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
@@ -60,7 +60,7 @@ describe("2d_array.html", () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
                 table._invalid_schema = true;
-                table.scrollTo(0, 4, 3, 26);
+                table.scrollToCell(0, 4, 3, 26);
                 await table.draw({invalid_viewport: true});
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");

--- a/test/examples/two_billion_rows.test.js
+++ b/test/examples/two_billion_rows.test.js
@@ -84,7 +84,7 @@ describe("two_billion_rows.html", () => {
         });
     });
 
-    describe("scrolls via scrollTo() method", () => {
+    describe("scrolls via scrollToCell() method", () => {
         beforeAll(async () => {
             await page.goto("http://localhost:8081/dist/examples/two_billion_rows.html");
             await page.waitFor("regular-table table tbody tr td");
@@ -93,7 +93,7 @@ describe("two_billion_rows.html", () => {
         test.skip("https://github.com/jpmorganchase/regular-table/issues/15", async () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
-                table.scrollTo(0, 250500, 1000, 2000000000);
+                table.scrollToCell(0, 250500, 1000, 2000000000);
                 await table.draw();
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");

--- a/test/features/scrollTo.test.js
+++ b/test/features/scrollTo.test.js
@@ -8,7 +8,7 @@
  *
  */
 
-describe("scrollTo", () => {
+describe("scrollToCell", () => {
     beforeAll(async () => {
         await page.setViewport({width: 200, height: 200});
         await page.goto("http://localhost:8081/test/features/2_row_2_column_headers.html");
@@ -26,11 +26,11 @@ describe("scrollTo", () => {
     });
 
     describe("sets the correct position", () => {
-        test("for scrollTo position {x: 2, y: 0}", async () => {
+        test("for scrollToCell position {x: 2, y: 0}", async () => {
             const table = await page.$("regular-table");
 
             await page.evaluate(async (table) => {
-                table.scrollTo(2, 0, 1000, 1000);
+                table.scrollToCell(2, 0, 1000, 1000);
                 await table.draw();
             }, table);
 
@@ -40,11 +40,11 @@ describe("scrollTo", () => {
             expect(meta.x).toEqual(1);
         });
 
-        test("for scrollTo position {x: 1000, y: 0}", async () => {
+        test("for scrollToCell position {x: 1000, y: 0}", async () => {
             const table = await page.$("regular-table");
 
             await page.evaluate(async (table) => {
-                table.scrollTo(1000, 0, 1000, 1000);
+                table.scrollToCell(1000, 0, 1000, 1000);
                 await table.draw();
             }, table);
 
@@ -54,11 +54,11 @@ describe("scrollTo", () => {
             expect(meta.x).toEqual(999);
         });
 
-        test("for scrollTo position {x: 0, y: 1}", async () => {
+        test("for scrollToCell position {x: 0, y: 1}", async () => {
             const table = await page.$("regular-table");
 
             await page.evaluate(async (table) => {
-                table.scrollTo(0, 1, 1000, 1000);
+                table.scrollToCell(0, 1, 1000, 1000);
                 await table.draw();
             }, table);
 
@@ -68,10 +68,10 @@ describe("scrollTo", () => {
             expect(meta.y).toEqual(1);
         });
 
-        test("for scrollTo position {x: 211, y: 647}", async () => {
+        test("for scrollToCell position {x: 211, y: 647}", async () => {
             const table = await page.$("regular-table");
             await page.evaluate(async (table) => {
-                table.scrollTo(211, 647, 1000, 1000);
+                table.scrollToCell(211, 647, 1000, 1000);
                 await table.draw();
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,10 +1253,23 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
   integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/react@^16.9.38":
+  version "16.9.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.38.tgz#868405dace93a4095d3e054f4c4a1de7a1ac0680"
+  integrity sha512-pHAeZbjjNRa/hxyNuLrvbxhhnKyKNiLC6I5fRF2Zr/t/S6zS41MiyzH4+c+1I9vVfvuRt1VS2Lodjr4ZWnxrdA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2613,6 +2626,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^2.2.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 cwd@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
I've tested this PR out by `yarn linking`-ing it into an external typescript project. The typings seems to work well.

- 4069dec - this one adds the actual `index.d.ts`
- 9bd534d - minor fixups to jsdocs to match 4069dec
- 1406f41  - fixes #54: renamed `scrollTo` -> `scrollToCell`, so that the method can be included in `index.d.ts` without the typescript compiler complaining about shadowing of the base class method

@texodus 9bd534d added docstrings for the `RegularTableElement` private methods:
- on the genreral principle that the more (dev) docs, the better
- I added `@internal @private` tags to the private docstrings. In theory, that means these private docstrings will get ignored both by jsdoc and [at least one declaration generator](https://api-extractor.com/pages/setup/configure_rollup/) that we can experiment with later
- if you think these aren't appropriate, I can also just get rid of them