### PR TITLE
Bug fixes for `perspective.md` and iOS

### DIFF
--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -334,7 +334,8 @@ async function dataListener(x0, y0, x1, y1) {
     const column_headers = [];
     for (const path of this._column_paths.slice(x0, x1)) {
         const path_parts = path.split("|");
-        data.push(columns[path].map((x) => _format.call(this, path_parts, x)));
+        const column = columns[path] || [];
+        data.push(column.map((x) => _format.call(this, path_parts, x)));
         column_headers.push(path_parts);
     }
 
@@ -348,7 +349,11 @@ async function dataListener(x0, y0, x1, y1) {
 }
 ```
 
-Create a model state object.
+Create a model state object.  This object will memoize everything that a
+`regular-table` will need in one place, minimizing recalculation later when
+a re-render is requested.  Because some operations like _sorting_ can actually
+instantiate a view (and this call `createViewCache()` themselves), we must
+memoize both the `Table` and `View` objects.
 
 ```javascript
 async function createViewCache(table, view, extend = {}) {
@@ -369,16 +374,22 @@ async function createViewCache(table, view, extend = {}) {
 ```javascript
 async function configureRegularTable(regular, model) {
     regular.setDataListener(dataListener.bind(model));
-
     regular.addStyleListener(typeStyleListener.bind(model, regular));
     regular.addStyleListener(treeStyleListener.bind(model, regular));
     regular.addStyleListener(groupHeaderStyleListener.bind(model, regular));
     regular.addStyleListener(columnHeaderStyleListener.bind(model, regular));
-
     regular.addEventListener("mousedown", mousedownListener.bind(model, regular));
-
     await regular.draw();
 }
+```
+
+The functions `configureRegularTable()` and `createViewCache()` are all that's
+needed to wire a `Table` to a `regular-table`, so we'll export these for
+convenient inclusion in a module-aware Javascript project.
+
+```javascript
+exports.createViewCache = createViewCache;
+exports.configureRegularTable = configureRegularTable;
 ```
 
 ## Perspective

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -13,14 +13,14 @@
 export const METADATA_MAP = new WeakMap();
 
 // Output runtime debug info like FPS.
-export const DEBUG = true;
+export const DEBUG = false;
 
 // Double buffer when the viewport scrolls columns, rows or when the
 // view is recreated.  Reduces render draw-in on some browsers, at the
 // expense of performance.
 export const DOUBLE_BUFFER_COLUMN = false;
 export const DOUBLE_BUFFER_ROW = false;
-export const DOUBLE_BUFFER_RECREATE = false;
+export const DOUBLE_BUFFER_RECREATE = true;
 
 // The largest size virtual <div> in (px) that Chrome can support without
 // glitching.

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -23,6 +23,7 @@ regular-table {
     // firefox scrollbar styling
     scrollbar-color: transparent transparent;
     scrollbar-width: thin;
+    outline: none;
 }
 
 regular-table:hover {

--- a/test/examples/area_mouse_selection.test.js
+++ b/test/examples/area_mouse_selection.test.js
@@ -19,7 +19,7 @@ describe("area_mouse_selection.html", () => {
     };
 
     beforeAll(async () => {
-        await page.setViewport({width: 2500, height: 2500});
+        await page.setViewport({width: 300, height: 300});
         await page.goto("http://localhost:8081/dist/examples/area_mouse_selection.html");
         await page.waitFor("regular-table table tbody tr td");
     });

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -108,7 +108,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th_value = await page.evaluate((th) => th.innerHTML, ths[0]);
@@ -161,7 +161,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);


### PR DESCRIPTION
Fixes bugs:
* Fixes `perspective.md` to generate a well-formed response when the underlying `Table` is empty.  `perspective` itself returns an empty object in this case, though arguably it should provide the column_header keys, this is still potentially logically empty in the case of `column_pivots`.
* Fixes a CSS quirk which makes interaction events apply `::select` pseudoclass and styling.
* Fixes a regression in iOS which causes virtual scrolling to "bounce" along with the headers in a fairly unattractive way, at the expense of scroll inertia.  We may need to revisit this if scroll inertia is a popular feature ...