### PR TITLE
Adds `clear()` method

### DIFF
--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -118,6 +118,7 @@ tbody th:empty {
     color: #ccc;
     font-family: "Material Icons";
     padding-right: 11px;
+    vertical-align: -1px;
 }
 .psp-tree-label-expand:before {
     content: "add"
@@ -254,11 +255,13 @@ async function expandCollapseHandler(regularTable, event) {
     regularTable.draw();
 }
 
-async function mousedownListener(regularTable, event) {
+function mousedownListener(regularTable, event) {
     if (event.target.classList.contains("psp-tree-label") && event.offsetX < 26) {
         expandCollapseHandler.call(this, regularTable, event);
+        event.handled = true;
     } else if (event.target.classList.contains("psp-header-leaf")) {
         sortHandler.call(this, regularTable, event);
+        event.handled = true;
     }
 }
 ```
@@ -326,8 +329,9 @@ async function dataListener(x0, y0, x1, y1) {
             start_col: x0,
             end_row: y1,
             end_col: x1,
-            id: this._config.row_pivots.length > 0,
+            id: true,
         });
+        this._ids = columns.__ID__;
     }
 
     const data = [];
@@ -364,6 +368,7 @@ async function createViewCache(regular, table, view, extend = {}) {
         _config: await view.get_config(),
         _num_rows: await view.num_rows(),
         _schema: await view.schema(),
+        _ids: [],
         _column_paths: (await view.column_paths()).filter((path) => {
             return path !== "__ROW_PATH__" && path !== "__ID__";
         }),

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -46,7 +46,6 @@ class RegularTableElement extends RegularViewEventModel {
             this._column_sizes = {auto: {}, override: {}, indices: []};
             this._style_callbacks = new Map();
             this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
-            if (!this.table_model) return;
             if (this !== this._sticky_container.parentElement) {
                 this.appendChild(this._sticky_container);
             }
@@ -99,6 +98,16 @@ class RegularTableElement extends RegularViewEventModel {
             th.style.minWidth = "";
             th.style.maxWidth = "";
         }
+    }
+
+    /**
+     * Clears the current renderer `<table>`.
+     *
+     * @public
+     * @memberof RegularTableElement
+     */
+    clear() {
+        this.table_model.clear(this._table_clip);
     }
 
     /**

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -22,12 +22,7 @@ import {html} from "./utils";
  */
 export class RegularTableViewModel {
     constructor(table_clip, column_sizes, element) {
-        element.innerHTML = html`
-            <table cellspacing="0">
-                <thead></thead>
-                <tbody></tbody>
-            </table>
-        `;
+        this.clear(element);
         const [table] = element.children;
         const [thead, tbody] = table.children;
         this.table = table;
@@ -39,6 +34,15 @@ export class RegularTableViewModel {
 
     num_columns() {
         return this.header._get_row(Math.max(0, this.header.rows?.length - 1 || 0)).row_container.length;
+    }
+
+    clear(element) {
+        element.innerHTML = html`
+            <table cellspacing="0">
+                <thead></thead>
+                <tbody></tbody>
+            </table>
+        `;
     }
 
     /**


### PR DESCRIPTION
Adds a public `clear()` method, which explicitly resets the rendering state to an empty `<table>`.