### PR TITLE
Fix `replace()` and unintentional interactive elements.

### DIFF
--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -132,6 +132,9 @@ tbody th:empty {
     color: #1078d1;
     text-shadow: 0px 0px 5px #1078d1;
 }
+tr:hover th.psp-tree-leaf, tr:hover th.psp-tree-label  {
+    background: #eee;
+}
 .psp-tree-leaf {
     padding-left: 24px;
 }

--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -25,6 +25,7 @@ function columnHeaderStyleListener(regularTable) {
         td.classList.toggle("psp-header-border", needs_border);
         td.classList.toggle("psp-header-group", false);
         td.classList.toggle("psp-header-leaf", true);
+        td.classList.toggle("psp-header-corner", typeof metadata.x === "undefined");
         td.classList.toggle("psp-header-sort-asc", !!sort && sort[1] === "asc");
         td.classList.toggle("psp-header-sort-desc", !!sort && sort[1] === "desc");
         td.classList.toggle("psp-header-sort-col-asc", !!sort && sort[1] === "col asc");
@@ -109,6 +110,7 @@ tbody th:empty {
     background-repeat: no-repeat;
     min-width: 20px;
     max-width: 20px;
+    pointer-events: none;
 }
 .psp-tree-label {
     max-width: 0px;
@@ -169,10 +171,10 @@ CSS:
 .psp-align-left {
     text-align: left;
 }
-.psp-positive {
+.psp-positive:not(:focus) {
     color: #1078d1;
 }
-.psp-negative {
+.psp-negative:not(:focus) {
     color: #de3838;
 }
 ```
@@ -259,7 +261,7 @@ function mousedownListener(regularTable, event) {
     if (event.target.classList.contains("psp-tree-label") && event.offsetX < 26) {
         expandCollapseHandler.call(this, regularTable, event);
         event.handled = true;
-    } else if (event.target.classList.contains("psp-header-leaf")) {
+    } else if (event.target.classList.contains("psp-header-leaf") && !event.target.classList.contains("psp-header-corner")) {
         sortHandler.call(this, regularTable, event);
         event.handled = true;
     }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "jest-puppeteer": "^4.4.0",
         "jsdoc-to-markdown": "^6.0.1",
         "less": "^3.9.0",
-        "literally-cli": "^0.0.6",
+        "literally-cli": "^0.0.7",
         "marked-ast-markdown": "^2.1.0",
         "npm-run-all": "^4.1.3",
         "prettier": "^2.0.5",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -142,6 +142,9 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
             element.style.maxWidth = "";
             for (const row of this.table_model.body.cells) {
                 const td = row[metadata._virtual_x];
+                if (!td) {
+                    continue;
+                }
                 td.style.minWidth = "";
                 td.style.maxWidth = "";
                 td.classList.remove("pd-cell-clip");

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -107,7 +107,7 @@ class RegularTableElement extends RegularViewEventModel {
      * @memberof RegularTableElement
      */
     clear() {
-        this.table_model.clear(this._table_clip);
+        this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
     }
 
     /**
@@ -208,10 +208,11 @@ class RegularTableElement extends RegularViewEventModel {
      * @example
      * table.scrollToCell(1, 3, 10, 30);
      */
-    scrollToCell(x, y, ncols, nrows) {
+    async scrollToCell(x, y, ncols, nrows) {
         const row_height = this._virtual_panel.offsetHeight / nrows;
         this.scrollTop = row_height * y;
         this.scrollLeft = (x / (this._max_scroll_column(ncols) || ncols)) * (this.scrollWidth - this.clientWidth);
+        await this.draw();
     }
 
     /**

--- a/src/less/material.less
+++ b/src/less/material.less
@@ -231,6 +231,9 @@ regular-table {
     }
 
     &:hover::-webkit-scrollbar-thumb {
+        background-color: rgba(0,0,0,0.15);
+    }
+    &::-webkit-scrollbar-thumb:hover {
         background-color: rgba(0,0,0,0.3);
     }
 }

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -95,7 +95,7 @@ describe("spreadsheet.html", () => {
             for (const td of tr) {
                 cell_values.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cell_values).toEqual(["Hello, World!", "", "", "", "", ""]);
+            expect(cell_values).toEqual(["Hello, World!", "", ""]);
         });
 
         test("scrolls as right arrow is down", async () => {
@@ -161,7 +161,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5201,10 +5201,10 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-literally-cli@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/literally-cli/-/literally-cli-0.0.6.tgz#b7430e45b8c8d628a3b28de98a268b9798f63f14"
-  integrity sha512-fOiUpZ36HtUhGx2KQoOGbkoMsqX8gykRADrd84aY4pfovWbzEv2F6OTw80XhOekqMfsndAs+23p9sbhnliC1sw==
+literally-cli@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/literally-cli/-/literally-cli-0.0.7.tgz#221ef9e96c9cbea9de618106a0db5a798ab67599"
+  integrity sha512-HpLCAe7VH+1mn4VznmZntWqNLsWpSf7lZSbTkaSbeah7bDT199rQ4Rt8Oud1Rnmw3BzLF8lFWOY3QQTmRd1mgw==
   dependencies:
     chalk "^4.1.0"
     commander "^5.1.0"


### PR DESCRIPTION
* Fixes the `replace()` method.  The previous implementation reset `innerHTML`, but a subtle race condition allowed the old DOM nodes to still be updated by `regular-table`;  the new `clear()` replaces the entire `table_model`.
* Fixes a few unintentional mouse interactions:
    * Clicking on the tree axis itself.
    * Clicking on the "corner" and applying a sort of a negative column ..
    
