### PR TITLE
Refactor perspective.md sort to abstract mutable state via sorting

### DIFF
--- a/test/examples/perspective.test.js
+++ b/test/examples/perspective.test.js
@@ -53,9 +53,7 @@ describe("perspective.html", () => {
         describe("headers sorted when clicked", () => {
             beforeAll(async () => {
                 await page.click("thead tr:last-child th:last-child");
-                await page.evaluate(async () => {
-                    await document.querySelector("regular-table").draw();
-                });
+                await page.waitFor("regular-table th.psp-header-sort-desc");
             });
 
             test("with the correct column header leaves", async () => {
@@ -80,9 +78,7 @@ describe("perspective.html", () => {
         describe.skip("headers sorted when clicked a 2nd time", () => {
             beforeAll(async () => {
                 await page.click("thead tr:last-child th:last-child");
-                await page.evaluate(async () => {
-                    await document.querySelector("regular-table").draw();
-                });
+                await page.waitFor("regular-table th.psp-header-sort-asc");
             });
 
             test("with the correct column header leaves", async () => {


### PR DESCRIPTION
For the `perspective.md` example, a new `perspective.View()` can be created for each new sort config;  but when used as a basis for a `<perspective-viewer>` component, which manages and generates its own `perspective.View()`, we must delegate this responsibility externally, which this PR adds via a simple `CustomEvent`, `"regular-table-psp-sort"`, wihch is registered in the `.markdown` example's `html' top-level section.