### PR TITLE
`swap` option for `draw()`

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -15,13 +15,6 @@ export const METADATA_MAP = new WeakMap();
 // Output runtime debug info like FPS.
 export const DEBUG = false;
 
-// Double buffer when the viewport scrolls columns, rows or when the
-// view is recreated.  Reduces render draw-in on some browsers, at the
-// expense of performance.
-export const DOUBLE_BUFFER_COLUMN = false;
-export const DOUBLE_BUFFER_ROW = false;
-export const DOUBLE_BUFFER_RECREATE = true;
-
 // The largest size virtual <div> in (px) that Chrome can support without
 // glitching.
 const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -48,6 +48,7 @@ class RegularTableElement extends RegularViewEventModel {
             this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
             if (this !== this._sticky_container.parentElement) {
                 this.appendChild(this._sticky_container);
+                this.appendChild(this._table_staging);
             }
             this._initialized = true;
         }

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -111,7 +111,7 @@ export class RegularBodyViewModel extends ViewModel {
                 }
 
                 metadata = obj ? obj.metadata : metadata;
-                row_height = row_height || obj.td.offsetHeight;
+                row_height = row_height || obj?.td.offsetHeight;
                 if (ridx * row_height > container_height) {
                     break;
                 }


### PR DESCRIPTION
Adds the `swap` option for the `draw()` method, which replaces the existing constant value.  With this change, `<table>` swapping will _only_ occur when this flag is set.

```javascript
table.draw({swap: true});
```

In addition, the container element used for 'staging" changes during a swap has been moved to the light DOM, as a child of `<regular-table>`, sibling to the visible `<table>` container element.  This allows CSS style which may impact layout, such as font size and cell dimensions, to be calculated correctly in swapped mode; as a side effect however,  naive of async calls to `querySelector()` may resolve both hidden and cloned visible table elements. 