### PR TITLE
Style `swap` container element to visible

### DIFF
--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -84,7 +84,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         this._sticky_container = sticky_container;
         this._table_clip = table_clip;
         const table_staging = document.createElement("div");
-        table_staging.setAttribute("style", "display:none");
+        table_staging.setAttribute("style", "position:absolute;z-index:-1;opacity:0;pointer-event:none;");
         this.appendChild(table_staging);
         this._table_staging = table_staging;
         this._virtual_panel = virtual_panel;


### PR DESCRIPTION
Styles `swap` container element using `"opacity:0:z-index:-1:pointer-events:none"`, which (unlike `"display:none"`) allows correct dimension to be calculated during a `draw({swap: true})`.  This is applied inline due to its structural importance - this element should never be visible, even in the absence of an accompanying stylesheet.