### PR TITLE
Don't preventDefault() scroll when the table is at scroll min or max

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -70,14 +70,16 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         if (this._virtual_scrolling_disabled) {
             return;
         }
-        event.preventDefault();
-        event.returnValue = false;
-        const {clientWidth, clientHeight, scrollTop, scrollLeft} = this;
-        const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - clientHeight);
-        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - clientWidth);
-        this.scrollTop = Math.min(total_scroll_height, scrollTop + event.deltaY);
-        this.scrollLeft = Math.min(total_scroll_width, scrollLeft + event.deltaX);
-        this._on_scroll(event);
+        const {clientWidth, clientHeight, scrollTop, scrollLeft, scrollHeight} = this;
+        if ((event.deltaY > 0 && scrollTop + clientHeight < scrollHeight) || (event.deltaY < 0 && scrollTop > 0) || event.deltaY === 0) {
+            event.preventDefault();
+            event.returnValue = false;
+            const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - clientHeight);
+            const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - clientWidth);
+            this.scrollTop = Math.min(total_scroll_height, scrollTop + event.deltaY);
+            this.scrollLeft = Math.min(total_scroll_width, scrollLeft + event.deltaX);
+            this._on_scroll(event);
+        }
     }
 
     /**


### PR DESCRIPTION
When `regular-table` is embedded in a page or `HTMLElement` which is scrollable, the `<regular-table>` custom element will `preventDefault()` mousewheel and touch events, causing these actions to not scroll the parent.  As do embedded scrollable standard `HTMLElements`s already, this PR makes `<regular-table>` stop intercepting these events when the scroll container is at its min or max position.