### PR TITLE
Fixed `perspective` example bug

### DIFF
--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -353,7 +353,7 @@ async function dataListener(x0, y0, x1, y1) {
     const column_headers = [];
     for (const path of this._column_paths.slice(x0, x1)) {
         const path_parts = path.split("|");
-        const column = columns[path] || [];
+        const column = columns[path] || new Array(y1 - y0).fill(null);
         data.push(column.map((x) => _format.call(this, path_parts, x)));
         column_headers.push(path_parts);
     }
@@ -420,6 +420,7 @@ needed to wire a `Table` to a `regular-table`, so we'll export these for
 convenient inclusion in a module-aware Javascript project.
 
 ```javascript
+exports.formatters = FORMATTERS;
 exports.createModel = createModel;
 exports.configureRegularTable = configureRegularTable;
 ```


### PR DESCRIPTION
Fixes a rendering issue with `perspective.md` example's `dataListener()` method, which caused it to generate malformed `regular-table`responses in the presence of column pivots who become empty due to the presence of filter conditions.

<img width="830" alt="Screen Shot 2020-09-21 at 2 06 28 AM" src="https://user-images.githubusercontent.com/60666/93736699-1f3a8980-fbaf-11ea-8815-4462a3ca445b.png">
