### PR TITLE
Don't attempt to register web component if already created

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -248,7 +248,9 @@ class RegularTableElement extends RegularViewEventModel {
     }
 }
 
-window.customElements.define("regular-table", RegularTableElement);
+if (document.createElement("regular-table").constructor === HTMLElement) {
+    window.customElements.define("regular-table", RegularTableElement);
+}
 
 /**
  * An object with performance statistics about calls to


### PR DESCRIPTION
The browser complains loudly and there may be some other side effects (e.g. in `perspective`'s fat webpack bundle when used with other libraries that leverage regular-table, such as `ipyregulartable`)