### PR TITLE
Incrementally call styleHandlers, and remove intermediate <div>

### DIFF
--- a/examples/canvas_data_model.md
+++ b/examples/canvas_data_model.md
@@ -68,12 +68,7 @@ regular-table {
     height: 400px;
     pointer-events: none;
 }
-regular-table > div {
-    padding: 0px;
-    border: 1px solid white;
-    border-top-width: 0;
-    border-left-width: 0;
-}
+
 regular-table::-webkit-scrollbar-thumb {
     background-color: #fff !important;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    preset: "jest-puppeteer",
+    preset: process.platform === "darwin" ? "jest-puppeteer-docker" : "jest-puppeteer",
     transform: {},
     coverageDirectory: "coverage",
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "http-server": "^0.12.3",
         "jest": "^26.0.1",
         "jest-puppeteer": "^4.4.0",
+        "jest-puppeteer-docker": "^1.4.2",
         "jsdoc-to-markdown": "^6.0.1",
         "less": "^3.9.0",
         "literally-cli": "^0.0.7",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -129,7 +129,7 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         let element = event.target;
         while (element.tagName !== "TD" && element.tagName !== "TH") {
             element = element.parentElement;
-            if (!this._sticky_container.contains(element)) {
+            if (!this.contains(element)) {
                 return;
             }
         }
@@ -171,7 +171,7 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         let element = event.target;
         while (element.tagName !== "TD" && element.tagName !== "TH") {
             element = element.parentElement;
-            if (!this._sticky_container.contains(element)) {
+            if (!this.contains(element)) {
                 return;
             }
         }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -209,7 +209,7 @@ class RegularTableElement extends RegularViewEventModel {
         const row_height = this._virtual_panel.offsetHeight / nrows;
         this.scrollTop = row_height * y;
         this.scrollLeft = (x / (this._max_scroll_column(ncols) || ncols)) * (this.scrollWidth - this.clientWidth);
-        await this.draw();
+        await this.draw.flush();
     }
 
     /**

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,11 +45,7 @@ class RegularTableElement extends RegularViewEventModel {
             this.setAttribute("tabindex", "0");
             this._column_sizes = {auto: {}, override: {}, indices: []};
             this._style_callbacks = new Map();
-            this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
-            if (this !== this._sticky_container.parentElement) {
-                this.appendChild(this._sticky_container);
-                this.appendChild(this._table_staging);
-            }
+            this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this);
             this._initialized = true;
         }
     }
@@ -108,7 +104,7 @@ class RegularTableElement extends RegularViewEventModel {
      * @memberof RegularTableElement
      */
     clear() {
-        this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
+        this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this);
     }
 
     /**

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -142,7 +142,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         const header_levels = this._view_cache.config.column_pivots.length + 1;
         // TODO use cached height?
         const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this.clientHeight);
-        const percent_scroll = this.scrollTop / total_scroll_height;
+        const percent_scroll = Math.max(this.scrollTop, 0) / total_scroll_height;
         const virtual_panel_row_height = height / row_height;
         const relative_nrows = !reset_scroll_position ? this._nrows || 0 : nrows;
         const scroll_rows = Math.max(0, relative_nrows + (header_levels - virtual_panel_row_height));

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -321,7 +321,20 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         this._update_virtual_panel_height(num_rows);
 
         if (this._invalid_schema || invalid_row || invalid_column || invalid_viewport) {
-            const last_cells = await this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns);
+            this.dispatchEvent(
+                new CustomEvent("regular-table-before-update", {
+                    bubbles: true,
+                    detail: this,
+                })
+            );
+
+            let last_cells;
+            for await (last_cells of this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns)) {
+                for (const callback of this._style_callbacks.values()) {
+                    await callback({detail: this});
+                }
+            }
+
             this.table_model.autosize_cells(last_cells);
             if (!preserve_width) {
                 this._update_virtual_panel_width(this._invalid_schema || invalid_column || invalid_viewport, num_columns);

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -78,15 +78,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             </div>
         `;
 
-        const sticky_container = document.createElement("div");
-        sticky_container.setAttribute("tabindex", "0");
         const [, virtual_panel, table_clip] = this.shadowRoot.children;
-        this._sticky_container = sticky_container;
         this._table_clip = table_clip;
-        const table_staging = document.createElement("div");
-        table_staging.setAttribute("style", "position:absolute;z-index:-1;opacity:0;pointer-event:none;");
-        this.appendChild(table_staging);
-        this._table_staging = table_staging;
         this._virtual_panel = virtual_panel;
     }
 
@@ -235,50 +228,6 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     }
 
     /**
-     * Step 1 of a double-buffer render, swaps in a duplicate table and appends
-     * the real table to the hidden shadow DOM for mutation.
-     *
-     * @param {*} invalid
-     * @memberof RegularVirtualTableViewModel
-     */
-    _swap_in(swap) {
-        this.dispatchEvent(
-            new CustomEvent("regular-table-before-update", {
-                bubbles: true,
-                detail: this,
-            })
-        );
-        if (!this._virtual_scrolling_disabled) {
-            if (swap) {
-                if (this._sticky_container === this.table_model.table.parentElement) {
-                    this._sticky_container.replaceChild(this.table_model.table.cloneNode(true), this.table_model.table);
-                }
-                this._table_staging.appendChild(this.table_model.table);
-            } else {
-                if (this._sticky_container !== this.table_model.table.parentElement) {
-                    this._sticky_container.replaceChild(this.table_model.table, this._sticky_container.children[0]);
-                }
-            }
-        }
-    }
-
-    /**
-     * Step 2 of a double-buffer render, swap the original table back into the
-     * light DOM.
-     *
-     * @param {*} invalid
-     * @memberof RegularVirtualTableViewModel
-     */
-    async _swap_out(swap) {
-        if (!this._virtual_scrolling_disabled && swap) {
-            this._sticky_container.replaceChild(this.table_model.table, this._sticky_container.children[0]);
-        }
-        for (const callback of this._style_callbacks.values()) {
-            await callback({detail: this});
-        }
-    }
-
-    /**
      * Updates the `virtual_panel` width based on view state.
      *
      * @param {*} invalid
@@ -372,9 +321,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         this._update_virtual_panel_height(num_rows);
 
         if (this._invalid_schema || invalid_row || invalid_column || invalid_viewport) {
-            this._swap_in(swap);
             const last_cells = await this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns);
-            await this._swap_out(swap);
             this.table_model.autosize_cells(last_cells);
             if (!preserve_width) {
                 this._update_virtual_panel_width(this._invalid_schema || invalid_column || invalid_viewport, num_columns);

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -106,7 +106,6 @@ export class RegularHeaderViewModel extends ViewModel {
                     group_meta.size_key = metadata.size_key;
                 }
                 th.removeAttribute("colspan");
-                th.dataset.sizeKey = metadata.size_key;
             }
             if (metadata) {
                 metadata.x = x;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -106,5 +106,8 @@ export function throttlePromise(target, property, descriptor) {
             return result;
         }
     };
+    descriptor.value.flush = function () {
+        return this[lock];
+    };
     return descriptor;
 }

--- a/test/examples/fixed_column_widths.test.js
+++ b/test/examples/fixed_column_widths.test.js
@@ -74,7 +74,7 @@ describe("fixed_column_widths.html", () => {
         test("ths do not allow text selection", async () => {
             const first_tr = await page.$("regular-table thead tr:first-child");
             const user_selects = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => getComputedStyle(x).getPropertyValue("user-select")), first_tr);
-            expect(user_selects).toEqual(["none", "none", "none", "none"]);
+            expect(user_selects).toEqual(["none", "none", "none", "none", "none", "none"]);
         });
     });
 });

--- a/test/examples/perspective.test.js
+++ b/test/examples/perspective.test.js
@@ -52,7 +52,7 @@ describe("perspective.html", () => {
 
         describe("headers sorted when clicked", () => {
             beforeAll(async () => {
-                await page.click("thead tr:last-child th:last-child");
+                await page.click("thead tr:last-child th + th:nth-child(5)");
                 await page.waitFor("regular-table th.psp-header-sort-desc");
             });
 
@@ -71,7 +71,7 @@ describe("perspective.html", () => {
                 for (const tr of first_tr) {
                     cell_values.push(await page.evaluate((tr) => tr.innerHTML, tr));
                 }
-                expect(cell_values).toEqual(["TOTAL", "", "West", "", "California", "", "Los Angeles", "San Francisco", "San Diego", "Sacramento", "Anaheim", "Brentwood", "San Jose"]);
+                expect(cell_values).toEqual(["TOTAL", "", "West", "", "California", "", "Los Angeles", "San Francisco", "San Diego", "Anaheim", "Fresno", "Sacramento", "San Jose"]);
             });
         });
 

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -23,6 +23,7 @@ describe("spreadsheet.html", () => {
                 event.ctrlKey = true;
                 event.keyCode = 13;
                 table.dispatchEvent(event);
+                await table.draw();
             }, table);
         };
 
@@ -34,6 +35,7 @@ describe("spreadsheet.html", () => {
                     event.ctrlKey = true;
                     event.keyCode = 13;
                     table.dispatchEvent(event);
+                    await table.draw();
                 }, table);
             });
         };
@@ -45,6 +47,7 @@ describe("spreadsheet.html", () => {
                     event.initEvent("keydown", false, true);
                     event.keyCode = 37;
                     table.dispatchEvent(event);
+                    await table.draw();
                 }, table);
             });
         };
@@ -56,6 +59,7 @@ describe("spreadsheet.html", () => {
                     event.initEvent("keydown", false, true);
                     event.keyCode = 38;
                     table.dispatchEvent(event);
+                    await table.draw();
                 }, table);
             });
         };
@@ -67,6 +71,7 @@ describe("spreadsheet.html", () => {
                     event.initEvent("keydown", false, true);
                     event.keyCode = 39;
                     table.dispatchEvent(event);
+                    await table.draw();
                 }, table);
             });
         };
@@ -78,6 +83,7 @@ describe("spreadsheet.html", () => {
                     event.initEvent("keydown", false, true);
                     event.keyCode = 40;
                     table.dispatchEvent(event);
+                    await table.draw();
                 }, table);
             });
         };
@@ -108,7 +114,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "Hello, World!"]);
+            expect(cells.slice(cells.length - 5)).toEqual(["", "", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th_value = await page.evaluate((th) => th.innerHTML, ths[0]);
@@ -161,7 +167,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);

--- a/test/features/scrollTo.test.js
+++ b/test/features/scrollTo.test.js
@@ -76,7 +76,7 @@ describe("scrollToCell", () => {
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["Group 640", "Row 647", "858"]);
+            expect(cell_values).toEqual(["Group 640", "Row 647", "858", "859"]);
         });
     });
 });

--- a/test/features/scrolling.test.js
+++ b/test/features/scrolling.test.js
@@ -63,13 +63,13 @@ describe("scrolling", () => {
         test("with the correct # of columns", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const num_cells = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
-            expect(num_cells).toEqual(4);
+            expect(num_cells).toEqual(5);
         });
 
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.querySelectorAll("td")).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["16", "17"]);
+            expect(cell_values).toEqual(["16", "17", "18"]);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,6 +2775,11 @@ depd@^1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -2820,6 +2825,15 @@ dmd@^5.0.1:
     reduce-without "^1.0.1"
     test-value "^3.0.0"
     walk-back "^4.0.0"
+
+docker-chromium@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/docker-chromium/-/docker-chromium-1.4.2.tgz#952ff10eddce498314cab3983106f86650797702"
+  integrity sha512-gMnMj4C1+02OJCbeKSlS/SuIVY19mOFZXcDl5S46aUaFGYy9kiTDmBHzpJYsOIsdHi/qOcxuJgPE1eKEOx/Vwg==
+  dependencies:
+    colors "^1.4.0"
+    request "^2.88.2"
+    request-promise-native "^1.0.8"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3241,6 +3255,13 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect-puppeteer@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz#1c948af08acdd6c8cbdb7f90e617f44d86888886"
@@ -3433,6 +3454,14 @@ find-file-up@^0.1.2:
     fs-exists-sync "^0.1.0"
     resolve-dir "^0.1.0"
 
+find-node-modules@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-node-modules/-/find-node-modules-2.1.0.tgz#d9179cd1abd517622353f766da0807f912d21b06"
+  integrity sha512-aMVxgoGzmZQFzqouGzKpc573hAB7LVe/0ADEqE9GZIOd81dgYA+FD2nmYZy2ELdoEx9nBTdQGzDidhy9R0UX4Q==
+  dependencies:
+    findup-sync "^4.0.0"
+    merge "^1.2.1"
+
 find-pkg@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-0.1.2.tgz#1bdc22c06e36365532e2a248046854b9788da557"
@@ -3470,6 +3499,16 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+findup-sync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-4.0.0.tgz#956c9cdde804052b881b428512905c4a5f2cdef0"
+  integrity sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^4.0.0"
+    micromatch "^4.0.2"
+    resolve-dir "^1.0.1"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -3678,6 +3717,15 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -3687,6 +3735,17 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -3828,7 +3887,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-homedir-polyfill@^1.0.0:
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
   integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
@@ -4391,7 +4450,7 @@ is-windows@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
   integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
-is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -4711,6 +4770,15 @@ jest-pnp-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
+
+jest-puppeteer-docker@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jest-puppeteer-docker/-/jest-puppeteer-docker-1.4.2.tgz#b0a62e0bb8314d6b11a1e0c0c247693641763baf"
+  integrity sha512-7mCl2XGqfOn5tK+i/j0gXCbQxeIWeAwY5jcLFlWu8FWF23Ncb86xoU8DzNNV9ZpXavBIh+NQzHoPRN7lerMEgQ==
+  dependencies:
+    docker-chromium "^1.4.2"
+    find-node-modules "^2.0.0"
+    jest-puppeteer "^4.4.0"
 
 jest-puppeteer@^4.4.0:
   version "4.4.0"
@@ -5453,6 +5521,11 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+merge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 micromatch@^3.1.4:
   version "3.1.10"
@@ -7208,6 +7281,14 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -8801,7 +8882,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@^1.2.12, which@^1.2.9, which@^1.3.1:
+which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
A few big-picture API cleanup changes in this PR, and a few bugs:

* Refactors `perspective.md` model to separate `dataListener()` and `formatStyleListener()` into separate functions.  
* `styleHandler`s are now invoked incrementally when a column's widths are not known, with total width calculation being deferred until pagination.  This clears up a whole category of resize bugs involving columns failing to render for _just_ the first call to `draw()`.
* The default DOM structure has been simplified (due to browser bug fixes since publication) to remove an intermediate `<div>` layer.

```javascript 
<regular-table>
    <div>
        <table></table>
    </div>
</regular-table>
```
vs.
```javascript 
<regular-table>
    <table></table>
</regular-table>
```
* Fixes overscroll behavior due to browser "bounce" on browser which bounce.
* Fixes test instability via `jest-puppeteer-docker` for docker based image recreation.