### PR TITLE
Fixup jsdoc annotations, carry fixups over to typescript typings

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -29,8 +29,11 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
     }
 
     /**
+     *
+     * @internal
+     * @private
+     * @memberof RegularViewEventModel
      * @returns
-     * @memberof RegularViewModel
      */
     async _on_scroll(event) {
         event.stopPropagation();
@@ -45,6 +48,8 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * and disabled to achieve clean virtual scrolling in the presence of a
      * `fixed` element.
      *
+     * @internal
+     * @private
      * @memberof RegularViewEventModel
      */
     _register_glitch_scroll_listeners() {
@@ -63,8 +68,10 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * Mousewheel must precalculate in addition to `_on_scroll` to prevent
      * visual artifacts due to scrolling "inertia" on modern browsers.
      *
+     * @internal
+     * @private
+     * @memberof RegularViewEventModel
      * @param {*} event
-     * @memberof RegularViewModel
      */
     _on_mousewheel(event) {
         if (this._virtual_scrolling_disabled) {
@@ -88,9 +95,11 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * the unfortunate side-effect of disabling scroll intertia, but the
      * alternative is a dodgy, glitchy mess.
      *
+     * @internal
+     * @private
+     * @memberof RegularViewEventModel
      * @param {*} event
      * @returns
-     * @memberof RegularViewEventModel
      */
     _on_touchmove(event) {
         if (this._virtual_scrolling_disabled) {
@@ -110,8 +119,10 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * Memoize `touchstart` positions to calculate deltas, since these are not
      * generated on `touchmove` events.
      *
-     * @param {*} event
+     * @internal
+     * @private
      * @memberof RegularViewEventModel
+     * @param {*} event
      */
     _on_touchstart(event) {
         this._memo_touch_startY = event.touches[0].screenY;
@@ -121,9 +132,11 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
     /**
      * Handles double-click header width override reset.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} event
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     async _on_dblclick(event) {
         let element = event.target;
@@ -159,9 +172,11 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * Dispatches all click events to other handlers, depending on
      * `event.target`.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} event
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     async _on_click(event) {
         if (event.button !== 0) {
@@ -186,10 +201,12 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
     /**
      * Regular event for column resize.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} event
      * @param {*} element
      * @param {*} metadata
-     * @memberof RegularVirtualTableViewModel
      */
     _on_resize_column(event, element, metadata) {
         const start = event.pageX;
@@ -210,12 +227,14 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
     /**
      * Regular event for mouse movement when resizing a column.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} event
      * @param {*} th
      * @param {*} start
      * @param {*} width
      * @param {*} metadata
-     * @memberof RegularVirtualTableViewModel
      */
     @throttlePromise
     async _on_resize_column_move(event, th, start, width, metadata) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -302,7 +302,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * @property {number} [x1] - The `x` index of the viewport corner in
  * your data model, e.g. what was passed to `x1` when your
  * `dataListener` was invoked.
- * @property {number} [y1] - The `y` index of the viewport origin in
+ * @property {number} [y1] - The `y` index of the viewport corner in
  * your data model, e.g. what was passed to `y1` when your
  * `dataListener` was invoked.
  * @property {number} [dx] - The `x` index in `DataResponse.data`, this
@@ -312,7 +312,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * @property {number} [column_header_y] - The `y` index in
  * `DataResponse.column_headers[x]`, this property is only generated for `<th>`
  * from `column_headers`.
- * @property {number} [column_header_x] - The `x` index in
+ * @property {number} [row_header_x] - The `x` index in
  * `DataResponse.row_headers[y]`, this property is only generated for `<th>`
  * from `row_headers`.
  * @property {number} size_key - The unique index of this column in a full
@@ -321,6 +321,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * `DataResponse.row_headers`, if it was provided.
  * @property {Array<object>} [column_header] - The `Array` for this `x` in
  * `DataResponse.column_headers`, if it was provided.
+ * @property {object} [value] - The value dispalyed in the cell or header.
  */
 
 /**
@@ -373,8 +374,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * `Event`); and returns a `Promise` for a `DataResponse` object for this
  * region (as opposed to returning `void` as a standard event listener).
  *
- * @typedef DataListener
- * @type {function}
+ * @callback DataListener
  * @param {number} x0 - The origin `x` index (column).
  * @param {number} y0 - The origin `y` index (row).
  * @param {number} x1 - The corner `x` index (column).

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -61,6 +61,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * double buffered `<table>` is rendered in the shadow DOM before being
      * swapped in.
      *
+     * @internal
+     * @private
      * @memberof RegularVirtualTableViewModel
      */
     create_shadow_dom() {
@@ -86,10 +88,12 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     /**
      * Calculates the `viewport` argument for perspective's `to_columns` method.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} nrows
      * @param {*} reset_scroll_position
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     _calculate_viewport(nrows, num_columns, reset_scroll_position) {
         const {start_row, end_row} = this._calculate_row_range(nrows, reset_scroll_position);
@@ -131,10 +135,12 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      *        |                          |
      *  600px +--------------------------+
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} nrows
      * @param {*} reset_scroll_position
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     _calculate_row_range(nrows, reset_scroll_position) {
         const {height} = this._container_size;
@@ -156,8 +162,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * details of which are actually calculated in `_max_column`, the equivalent
      * of `total_scroll_height` from `_calculate_row_range`.
      *
-     * @returns
+     * @internal
+     * @private
      * @memberof RegularVirtualTableViewModel
+     * @returns
      */
     _calculate_column_range(num_columns) {
         const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - this._container_size.width);
@@ -189,8 +197,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      *   |                 | 80px  | 110px   | 100px  |
      *   |                 |       |         |        |
      *
-     * @returns
+     * @internal
+     * @private
      * @memberof RegularVirtualTableViewModel
+     * @returns
      */
     _max_scroll_column(num_columns) {
         let width = 0;
@@ -213,9 +223,11 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * e.g. when the logical (row-wise) viewport does not change, but the pixel
      * viewport has moved a few px.
      *
+     * @internal
+     * @private
+     * @memberof RegularVirtualTableViewModel
      * @param {*} {start_col, end_col, start_row, end_row}
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     _validate_viewport({start_col, end_col, start_row, end_row}) {
         const invalid_column = this._start_col !== start_col;
@@ -230,8 +242,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     /**
      * Updates the `virtual_panel` width based on view state.
      *
-     * @param {*} invalid
+     * @internal
+     * @private
      * @memberof RegularVirtualTableViewModel
+     * @param {*} invalid
      */
     _update_virtual_panel_width(invalid, num_columns) {
         if (invalid) {
@@ -257,8 +271,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
     /**
      * Updates the `virtual_panel` height based on the view state.
      *
-     * @param {*} nrows
+     * @internal
+     * @private
      * @memberof RegularVirtualTableViewModel
+     * @param {*} nrows
      */
     _update_virtual_panel_height(nrows) {
         const {row_height = 19} = this._column_sizes;
@@ -281,23 +297,25 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * interaction and previous render state.
      *
      * `reset_scroll_position` will not prevent the viewport from moving as
-     * `draw()` may change the dmiensions of the virtual_panel (and thus,
+     * `draw()` may change the dimensions of the virtual_panel (and thus,
      * absolute scroll offset).  This calls `reset_scroll`, which will
      * trigger `_on_scroll` and ultimately `draw()` again;  however, this call
      * to `draw()` will be for the same viewport and will not actually cause
      * a render.
      *
-     * @param {*} [options]
-     * @param {boolean} [options.reset_scroll_position=false]
+     * @public
+     * @memberof RegularVirtualTableViewModel
+     * @param {DrawOptions} [options]
+     * @param {boolean} [options.invalid_viewport=true]
      * @param {boolean} [options.preserve_width=false]
+     * @param {boolean} [options.reset_scroll_position=false]
      * @param {boolean} [options.swap=false]
      * @returns
-     * @memberof RegularVirtualTableViewModel
      */
     @throttlePromise
     async draw(options = {}) {
         const __debug_start_time__ = DEBUG && performance.now();
-        const {reset_scroll_position = false, preserve_width = false, invalid_viewport = true, swap = false} = options;
+        const {invalid_viewport = true, preserve_width = false, reset_scroll_position = false, swap = false} = options;
 
         if (reset_scroll_position) {
             this.reset_scroll();
@@ -347,3 +365,14 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         }
     }
 }
+
+/**
+ * Options for the draw method.
+ *
+ * @typedef DrawOptions
+ * @type {object}
+ * @property {boolean} [invalid_viewport]
+ * @property {boolean} [preserve_width]
+ * @property {boolean} [reset_scroll_position]
+ * @property {boolean} [swap]
+ */


### PR DESCRIPTION
Fixes #110

This PR fixes the typos and other minor issues in the jsdocs mentioned in #110, carries those fixes over to the typescript typings in `index.d.ts`, and makes a couple of other minor by-hand fixes to `index.d.ts`, such as including the `.draw` method in the `RegularTableElement` typing