### PR TITLE
Invalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ are also available.
     - [Hierarchial/Group Headers](#hierarchialgroup-headers)
     - [`async` Data Models](#async-data-models)
   - [`.addStyleListener()` and `getMeta()` Styling](#addstylelistener-and-getmeta-styling)
+    - [`.invalidate()`](#invalidate)
   - [`.addEventListener()` Interaction](#addeventlistener-interaction)
   - [Pivots, Filters, Sorts, and Column Expressions with `perspective`](#pivots-filters-sorts-and-column-expressions-with-perspective)
   - [Development](#development)
@@ -397,6 +398,28 @@ function style_th(th) {
 .zebra-striped {
     background-color: rgba(0,0,0,0.2);
 }
+```
+
+### `.invalidate()`
+
+To prevent DOM renders, `<regular-table>` conserves DOM calls like `offsetWidth`
+to an internal cache.  When a `<td>` or `<th>`'s `width` is modified within a 
+callback to `.addStyleListener()`, you must indicate to `<regular-table>` that
+its dimensions have changed in order to invalidate this cache, or you may not
+end up with enough rendered columns to fill the screen!
+
+A call to `invalidate()` that does not need new columns only imparts a small
+runtime overhead to re-calculate virtual width per async draw iteration, but
+should be used conservatively if possible.  Calling `invalidate()` outside of
+a callback to `.addStyleListener()` will throw an `Error`.
+
+```javascript
+table.addStyleListener(() => {
+    for (const th of table.querySelectorAll("tbody th")) {
+        th.style.maxWidth = "20px";
+    }
+    table.invalidate();
+});
 ```
 
 ## `.addEventListener()` Interaction

--- a/examples/fixed_column_widths.md
+++ b/examples/fixed_column_widths.md
@@ -62,6 +62,7 @@ const fixColumnWidths = (table, isFixed) => {
     }
 
     function styleListener() {
+        table.invalidate();
         const ths = table.querySelectorAll("thead th");
         const tds = table.querySelectorAll("tbody td");
         for (const cell of [...ths, ...tds]) {

--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -318,6 +318,7 @@ function _format(parts, val, use_table_schema = false) {
 }
 
 function formatStyleListener(regularTable) {
+    regularTable.invalidate();
     for (const td of regularTable.querySelectorAll("table tbody td")) {
         const metadata = regularTable.getMeta(td);
         let type = get_psp_type.call(this, metadata);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -134,6 +134,20 @@ class RegularTableElement extends RegularViewEventModel {
     }
 
     /**
+     * When called within the execution scope of a function registered to this
+     * `<regular-table>` as a `StyleListener`, invalidate this draw's
+     * dimensions and attempt to draw more columns.  Useful if your
+     * `StyleListener` changes a cells dimensions, otherwise `<regular-table>`
+     * may not draw enough columns to fill the screen.
+     */
+    invalidate() {
+        if (!this._is_styling) {
+            throw new Error("Cannot call `invalidate()` outside of a `StyleListener`");
+        }
+        this._invalidated = true;
+    }
+
+    /**
      * Returns the `MetaData` object associated with a `<td>` or `<th>`.  When
      * your `StyleListener` is invoked, use this method to look up additional
      * `MetaData` about any `HTMLTableCellElement` in the rendered `<table>`.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -91,7 +91,8 @@ class RegularTableElement extends RegularViewEventModel {
         this._column_sizes.override = {};
         this._column_sizes.indices = [];
 
-        for (const th of this.table_model.header.cells[this.table_model.header.cells.length - 1]) {
+        for (let i = 0; i < this.table_model.header.num_columns(); i++) {
+            const th = this.table_model.header.get_column_header(i);
             th.style.minWidth = "";
             th.style.maxWidth = "";
         }
@@ -157,16 +158,16 @@ class RegularTableElement extends RegularViewEventModel {
             return METADATA_MAP.get(element);
         } else if (element.row_header_x >= 0) {
             if (element.row_header_x < this._view_cache.config.row_pivots.length) {
-                const td = this.table_model.body.cells[element.y]?.[element.row_header_x];
+                const td = this.table_model.body._fetch_cell(element.y, element.row_header_x);
                 return this.getMeta(td);
             }
         } else if (element.column_header_y >= 0) {
             if (element.column_header_y < this._view_cache.config.column_pivots.length) {
-                const td = this.table_model.body.cells[element.column_header_y]?.[element.y];
+                const td = this.table_model.body._fetch_cell(element.column_header_y, element.y);
                 return this.getMeta(td);
             }
         } else {
-            return this.getMeta(this.table_model.body.cells[element.dy]?.[element.dx + this.table_model._row_headers_length]);
+            return this.getMeta(this.table_model.body._fetch_cell(element.dy, element.dx + this.table_model._row_headers_length));
         }
     }
 

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -262,7 +262,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      */
     _update_virtual_panel_height(nrows) {
         const {row_height = 19} = this._column_sizes;
-        const header_height = this.table_model.header.cells.length * row_height;
+        const header_height = this.table_model.header.num_rows() * row_height;
         let virtual_panel_px_size;
         if (this._virtual_scrolling_disabled) {
             virtual_panel_px_size = nrows * row_height + header_height;
@@ -281,7 +281,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * interaction and previous render state.
      *
      * `reset_scroll_position` will not prevent the viewport from moving as
-     * `draw()` may change the dmiensions of the virtual_panel (and thus,
+     * `draw()` may change the dimensions of the virtual_panel (and thus,
      * absolute scroll offset).  This calls `reset_scroll`, which will
      * trigger `_on_scroll` and ultimately `draw()` again;  however, this call
      * to `draw()` will be for the same viewport and will not actually cause

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -330,11 +330,17 @@ export class RegularVirtualTableViewModel extends HTMLElement {
 
             let last_cells;
             for await (last_cells of this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns)) {
+                this._is_styling = true;
                 for (const callback of this._style_callbacks.values()) {
                     await callback({detail: this});
                 }
-            }
+                this._is_styling = false;
 
+                if (!this._invalidated) {
+                    break;
+                }
+                this._invalidated = false;
+            }
             this.table_model.autosize_cells(last_cells);
             if (!preserve_width) {
                 this._update_virtual_panel_width(this._invalid_schema || invalid_column || invalid_viewport, num_columns);

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -33,7 +33,7 @@ export class RegularTableViewModel {
     }
 
     num_columns() {
-        return this.header._get_row(Math.max(0, this.header.rows?.length - 1 || 0)).row_container.length;
+        return this.header.num_columns();
     }
 
     clear(element) {

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -20,7 +20,7 @@ import {html} from "./utils.js";
  */
 export class RegularHeaderViewModel extends ViewModel {
     _draw_group_th(offset_cache, d, column) {
-        const th = this._get_cell("TH", d, offset_cache[d]);
+        const th = this._get_cell("TH", d, offset_cache[d] || 0);
         offset_cache[d] += 1;
         th.className = "";
         th.removeAttribute("colspan");
@@ -69,7 +69,7 @@ export class RegularHeaderViewModel extends ViewModel {
     }
 
     get_column_header(cidx) {
-        return this._get_cell("TH", this.rows.length - 1, cidx);
+        return this._get_cell("TH", this.num_rows() - 1, cidx);
     }
 
     _group_header_cache = [];

--- a/src/js/view_model.js
+++ b/src/js/view_model.js
@@ -25,6 +25,10 @@ export class ViewModel {
         this.rows = [];
     }
 
+    num_columns() {
+        return this._get_row(Math.max(0, this.rows.length - 1)).row_container.length;
+    }
+
     num_rows() {
         return this.cells.length;
     }

--- a/test/examples/fixed_column_widths.test.js
+++ b/test/examples/fixed_column_widths.test.js
@@ -74,7 +74,10 @@ describe("fixed_column_widths.html", () => {
         test("ths do not allow text selection", async () => {
             const first_tr = await page.$("regular-table thead tr:first-child");
             const user_selects = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => getComputedStyle(x).getPropertyValue("user-select")), first_tr);
-            expect(user_selects).toEqual(["none", "none", "none", "none", "none", "none"]);
+
+            // The viewport is 400px wide and the fixed columns are 100px
+            // accross, and ~20px of padding is four columns.
+            expect(user_selects).toEqual(["none", "none", "none", "none"]);
         });
     });
 });

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -167,7 +167,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);

--- a/test/features/scrollTo.test.js
+++ b/test/features/scrollTo.test.js
@@ -76,7 +76,7 @@ describe("scrollToCell", () => {
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["Group 640", "Row 647", "858", "859"]);
+            expect(cell_values).toEqual(["Group 640", "Row 647", "858"]);
         });
     });
 });

--- a/test/features/scrolling.test.js
+++ b/test/features/scrolling.test.js
@@ -63,13 +63,13 @@ describe("scrolling", () => {
         test("with the correct # of columns", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const num_cells = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
-            expect(num_cells).toEqual(5);
+            expect(num_cells).toEqual(4);
         });
 
         test("with the first row's cell test correct", async () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.querySelectorAll("td")).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["16", "17", "18"]);
+            expect(cell_values).toEqual(["16", "17"]);
         });
     });
 });


### PR DESCRIPTION
From the new documentation for this feature:


> To prevent DOM renders, `<regular-table>` conserves DOM calls like `offsetWidth` to an internal cache.  When a `<td>` or `<th>`'s `width` is modified within a callback to `.addStyleListener()`, you must indicate to `<regular-table>` that its dimensions have changed in order to invalidate this cache, or you may not end up with enough rendered columns to fill the screen!
>
> A call to `invalidate()` that does not need new columns only imparts a small runtime overhead to re-calculate virtual width per async draw iteration, but should be used conservatively if possible.  Calling `invalidate()` outside of a callback to `.addStyleListener()` will throw an `Error`.

```javascript
table.addStyleListener(() => {
    for (const th of table.querySelectorAll("tbody th")) {
        th.style.maxWidth = "20px";
    }
    table.invalidate();
});
```