### PR TITLE
Clean and autosize columns in incremental render passes

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -13,7 +13,7 @@
 export const METADATA_MAP = new WeakMap();
 
 // Output runtime debug info like FPS.
-export const DEBUG = false;
+export const DEBUG = true;
 
 // The largest size virtual <div> in (px) that Chrome can support without
 // glitching.

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -186,6 +186,8 @@ export class RegularTableViewModel {
                 dcidx++;
 
                 if (view_state.viewport_width > container_width) {
+                    this.body.clean({ridx: cont_body?.ridx || 0, cidx: _virtual_x});
+                    this.header.clean();
                     yield last_cells;
 
                     // If we make it here, this draw() call was invalidated by
@@ -206,7 +208,8 @@ export class RegularTableViewModel {
                     }
                 }
             }
-
+            this.body.clean({ridx: cont_body?.ridx || 0, cidx: _virtual_x});
+            this.header.clean();
             yield last_cells;
         } finally {
             this.body.clean({ridx: cont_body?.ridx || 0, cidx: _virtual_x});

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -124,6 +124,9 @@ export class RegularHeaderViewModel extends ViewModel {
 
     clean() {
         this._clean_columns(this._offset_cache);
+    }
+
+    reset_header_cache() {
         this._offset_cache = [];
         this._group_header_cache = [];
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -97,8 +97,6 @@ export function throttlePromise(target, property, descriptor) {
         let result;
         try {
             result = await f.call(this, ...args);
-        } catch (e) {
-            console.error(e);
         } finally {
             const l = this[lock];
             this[lock] = undefined;


### PR DESCRIPTION
Before calling `StyleListener` callbacks, remove nodes which are not part of this render pass.  This replicates behavior from before the introduction of the incremental rendering feature, and prevents `StyleListener` callbacks from styling nodes which lack metadata.