### PR TITLE
Update features / example - allow row selection anywhere

### DIFF
--- a/examples/row_mouse_selection.md
+++ b/examples/row_mouse_selection.md
@@ -416,15 +416,36 @@ function generateDataListener(num_rows, num_columns) {
 Now to kick off our example on `"load"` by adding an `EvenListener` that will set
 our `table`'s `DataListener` from `generateDataListener()`,
 `addRowMouseSelection()` and make an initial call to `draw()`.
+We will use `defaultRowSelection()` to show a few selections by default on load.
 
 ```html
 <script>
+function defaultRowSelection () {
+    MOUSE_SELECTED_ROWS = [
+        {
+            row_header: ["Group 10", "Row 11"],
+            y0: 11,
+            y1: 11,
+        }, {
+            row_header: ["Group 10", "Row 15"],
+            y0: 14,
+            y1: 15,
+        }, {
+            row_header: ["Group 10", "Row 18"],
+            y0: 17,
+            y1: 18,
+        }
+    ];
+}
+
 window.addEventListener("load", () => {
     const table = window.rowMouseSelectionRegularTable;
     if (table) {
         const dl = generateDataListener(200, 50);
         table.setDataListener(dl);
-        addRowMouseSelection(table, dl).draw();
+        addRowMouseSelection(table, dl);
+        defaultRowSelection();
+        table.draw();
     }
 });
 </script>

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -9,6 +9,7 @@ const hashes = {
     minesweeper: "96a9ed60d0250f7d3187c0fed5f5b78c",
     file_browser: "a7b7588c899e3953dd8580e81c51b3f9",
     spreadsheet: "3e0e3d6f8bf8b47294a7847b402b55fb",
+    row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
 };
 
 for (const file in hashes) {

--- a/test/examples/row_mouse_selection/selecting_one_row_range.test.js
+++ b/test/examples/row_mouse_selection/selecting_one_row_range.test.js
@@ -28,7 +28,7 @@ describe("row_mouse_selection.html", () => {
         test("selects the rows' headers and cells", async () => {
             const rowHeader1 = await page.$("regular-table tbody tr:nth-of-type(2) th");
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true });
                 th.dispatchEvent(event);
             }, rowHeader1);
 

--- a/test/examples/row_mouse_selection/splitting_one_row_range.test.js
+++ b/test/examples/row_mouse_selection/splitting_one_row_range.test.js
@@ -28,7 +28,7 @@ describe("row_mouse_selection.html", () => {
         test("selects the rows' headers and cells", async () => {
             const rowHeader1 = await page.$("regular-table tbody tr:nth-of-type(2) th");
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true });
                 th.dispatchEvent(event);
             }, rowHeader1);
 


### PR DESCRIPTION
Make Row Selection available on row click / selection.
Move Row Selection to a blocks compatible example.

![preview](https://user-images.githubusercontent.com/61175/110802006-c8536a00-824b-11eb-8f4d-3da11eaffe7a.png)

