### PR TITLE
wrap any plain text column headers in a `<span>`

### DIFF
--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -1,7 +1,7 @@
 ## Perspective
 
 An example of a multi-dimensional pivot table using [`regular-table`](https://github.com/jpmorganchase/regular-table)
-and [`perspective`](https://perspective.finos.org/). 
+and [`perspective`](https://perspective.finos.org/).
 
 ```html
 <regular-table></regular-table>
@@ -64,7 +64,7 @@ Accompanying CSS:
     content: "arrow_forward"
 }
 ```
- 
+
 
 Group headers, e.g. `column_headers` 0 - (N - 1).
 
@@ -199,8 +199,8 @@ can emit the event `"regular-table-psp-sort"` which we can then handle in the
 same scope that declares this `regular-table`.
 
 ```javascript
-async function sortHandler(regularTable, event) {
-    const meta = regularTable.getMeta(event.target);
+async function sortHandler(regularTable, event, target) {
+    const meta = regularTable.getMeta(target);
     const column_name = meta.column_header[meta.column_header.length - 1];
     const sort_method = event.shiftKey ? append_sort : override_sort;
     const sort = sort_method.call(this, column_name);
@@ -256,9 +256,9 @@ const ROW_COL_SORT_ORDER = {desc: "asc", asc: "col desc", "col desc": "col asc",
 ## Expand/Collapse Interaction
 
 ```javascript
-async function expandCollapseHandler(regularTable, event) {
-    const meta = regularTable.getMeta(event.target);
-    const is_collapse = event.target.classList.contains("psp-tree-label-collapse");
+async function expandCollapseHandler(regularTable, event, target) {
+    const meta = regularTable.getMeta(target);
+    const is_collapse = target.classList.contains("psp-tree-label-collapse");
     if (event.shiftKey && is_collapse) {
         this._view.set_depth(meta.row_header.filter((x) => x !== undefined).length - 2);
     } else if (event.shiftKey) {
@@ -274,11 +274,19 @@ async function expandCollapseHandler(regularTable, event) {
 }
 
 function mousedownListener(regularTable, event) {
-    if (event.target.classList.contains("psp-tree-label") && event.offsetX < 26) {
-        expandCollapseHandler.call(this, regularTable, event);
+    let target = event.target;
+    while (target.tagName !== "TD" && target.tagName !== "TH") {
+        target = target.parentElement;
+        if (!regularTable.contains(target)) {
+            return;
+        }
+    }
+
+    if (target.classList.contains("psp-tree-label") && event.offsetX < 26) {
+        expandCollapseHandler.call(this, regularTable, event, target);
         event.handled = true;
-    } else if (event.target.classList.contains("psp-header-leaf") && !event.target.classList.contains("psp-header-corner")) {
-        sortHandler.call(this, regularTable, event);
+    } else if (target.classList.contains("psp-header-leaf") && !target.classList.contains("psp-header-corner")) {
+        sortHandler.call(this, regularTable, event, target);
         event.handled = true;
     }
 }
@@ -443,7 +451,7 @@ exports.configureRegularTable = configureRegularTable;
 ```html
 <script>
     const URL = "/node_modules/superstore-arrow/superstore.arrow";
-    
+
     const datasource = async () => {
         const request = fetch(URL);
         const worker = window.perspective.worker();
@@ -483,7 +491,7 @@ regular-table table {
 ```
 
 ## Appendix (Dependencies)
-    
+
 ```html
 <script src="/node_modules/@finos/perspective/dist/umd/perspective.js"></script>
 <script src="/dist/umd/regular-table.js"></script>

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -9,7 +9,6 @@
  */
 
 import {ViewModel} from "./view_model";
-import {html} from "./utils.js";
 
 /**
  * <thead> view model.  This model accumulates state in the form of
@@ -25,10 +24,19 @@ export class RegularHeaderViewModel extends ViewModel {
         th.className = "";
         th.removeAttribute("colspan");
         th.style.minWidth = "0";
-        th.innerHTML = html`
-            ${column}
-            <span class="rt-column-resize"></span>
-        `;
+
+        th.textContent = "";
+        if (column instanceof HTMLElement) {
+            th.appendChild(column);
+        } else {
+            const span = document.createElement("span");
+            span.textContent = column;
+            th.appendChild(span);
+        }
+
+        const resizeSpan = document.createElement("span");
+        resizeSpan.className = "rt-column-resize";
+        th.appendChild(resizeSpan);
 
         return th;
     }

--- a/test/examples/column_mouse_selection/selecting_column_headers.test.js
+++ b/test/examples/column_mouse_selection/selecting_column_headers.test.js
@@ -13,7 +13,7 @@ describe("column_mouse_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };

--- a/test/examples/column_mouse_selection/selecting_one_column.test.js
+++ b/test/examples/column_mouse_selection/selecting_one_column.test.js
@@ -13,7 +13,7 @@ describe("column_mouse_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };

--- a/test/examples/column_mouse_selection/selecting_one_column_range.test.js
+++ b/test/examples/column_mouse_selection/selecting_one_column_range.test.js
@@ -13,7 +13,7 @@ describe("column_mouse_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };

--- a/test/examples/column_mouse_selection/selecting_two_columns.test.js
+++ b/test/examples/column_mouse_selection/selecting_two_columns.test.js
@@ -13,7 +13,7 @@ describe("column_mouse_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };

--- a/test/examples/column_mouse_selection/splitting_one_column_range.test.js
+++ b/test/examples/column_mouse_selection/splitting_one_column_range.test.js
@@ -13,7 +13,7 @@ describe("column_mouse_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };

--- a/test/examples/perspective.test.js
+++ b/test/examples/perspective.test.js
@@ -23,19 +23,19 @@ describe("perspective.html", () => {
             test("with the correct top grouped header", async () => {
                 const first_tr = await page.$("regular-table thead tr:first-child");
                 const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-                expect(cell_values).toEqual(["   ", " Furniture  "]);
+                expect(cell_values).toEqual(["", "Furniture"]);
             });
 
             test("with the correct middle grouped header", async () => {
                 const first_tr = await page.$("regular-table thead tr:nth-child(2)");
                 const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-                expect(cell_values).toEqual(["   ", " Bookcases  ", " Chairs  "]);
+                expect(cell_values).toEqual(["", "Bookcases", "Chairs"]);
             });
 
             test("with the correct bottom grouped header", async () => {
                 const first_tr = await page.$("regular-table thead tr:last-child");
                 const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-                expect(cell_values).toEqual(["   ", "   ", "   ", "   ", " Sales  ", " Profit  ", " Sales  ", " Profit  "]);
+                expect(cell_values).toEqual(["", "", "", "", "Sales", "Profit", "Sales", "Profit"]);
             });
         });
 
@@ -62,7 +62,7 @@ describe("perspective.html", () => {
                 for (const tr of first_tr) {
                     cell_values.push(await page.evaluate((tr) => tr.textContent, tr));
                 }
-                expect(cell_values.slice(0, 7)).toEqual(["   ", "   ", "   ", "   ", " Sales  ", " Profit  ", " Sales  "]);
+                expect(cell_values.slice(0, 7)).toEqual(["", "", "", "", "Sales", "Profit", "Sales"]);
             });
 
             test("with the correct first row's cells", async () => {
@@ -87,7 +87,7 @@ describe("perspective.html", () => {
                 for (const tr of first_tr) {
                     cell_values.push(await page.evaluate((tr) => tr.textContent, tr));
                 }
-                expect(cell_values.slice(0, 7)).toEqual(["   ", "   ", "   ", "   ", " Sales  ", " Profit  ", " Sales  "]);
+                expect(cell_values.slice(0, 7)).toEqual(["", "", "", "", "Sales", "Profit", "Sales"]);
             });
 
             test("with the correct first row's cells", async () => {

--- a/test/examples/row_column_area_selection/column_selection.test.js
+++ b/test/examples/row_column_area_selection/column_selection.test.js
@@ -13,7 +13,7 @@ describe("row_column_area_selection.html", () => {
         const selectedCells = await page.$$("regular-table thead th.mouse-selected-column");
         const selectedValues = [];
         for (const td of selectedCells) {
-            selectedValues.push(await page.evaluate((td) => td.innerHTML.trim().split(" ").slice(0, 2).join(" "), td));
+            selectedValues.push(await page.evaluate((td) => td.firstChild.innerHTML, td));
         }
         return selectedValues;
     };


### PR DESCRIPTION
As discussed with @texodus, this PR changes the creation of column header nodes such that any text is wrapped up in a `<span>` element before getting added. As opposed to now, where any text is just included as a raw text node.