### PR TITLE
Make column selection blocks example

### DIFF
--- a/examples/area_clipboard.md
+++ b/examples/area_clipboard.md
@@ -3,31 +3,38 @@
 This example adds clipboard edit interactions to the area selection behavior applied to a
 [`<regular-table>`](https://github.com/jpmorganchase/regular-table), allowing the user
 to select groups of cells then copy, paste and cut.
-
 First we'll add a `<regular-table>` to the page with an `id` accessible on the window
 object.
+
 ```html
 <regular-table id="areaClipboardInteractionsRegularTable"></regular-table>
 ```
+
 ## Extending Area Selection
+
 Now we'll need to make the area selection behavior available by including the `area_mouse_selection` example ...
+
 ```html
 <script src="/dist/examples/area_mouse_selection.js"></script>
 ```
+
 and we'll also need a quick helper `function` to `getSelectedAreas()`.
+
 ```javascript
 function getSelectedAreas() {
     return MOUSE_SELECTED_AREAS;
 }
 ```
+
 ## `addAreaClipboardInteractions()`
+
 We'll create a single function to add the clipboard behavior to the `<regular-table>`
 passed in as the first argument. Additionally, it will take the `DataListener` and a
 `function` to `write` edits to the `DataModel`. Its direct responsibilities include
 adding `EventListener`s and the clipboard interaction's `StyleListener`.
-
 Our `EventListener` will dispatch to each of the behaviors for copy, paste and cut
 as expected - we'll define those next.
+
 ```javascript
 const addAreaClipboardInteractions = (table, dl, write) => {
     const keyListener = (event) => {
@@ -59,13 +66,17 @@ const addAreaClipboardInteractions = (table, dl, write) => {
     return table;
 };
 ```
+
 For our `areaClipboardCopy()`, we'll need to keep track of the `AREA_CLIPBOARD_COPY_SELECTIONS`.
 Each will represent a rectangular selection using familiar attributes `x0` as the upper left and `y1` as the lower right.
+
 ```javascript
 let AREA_CLIPBOARD_COPY_SELECTIONS = [];
 ```
+
 We'll also keep track of the data we get from the `DataListener` for the areas selected
 mapping over the selections then transposing the collection.
+
 ```javascript
 let AREA_CLIPBOARD_COPIED_DATA = [];
 
@@ -75,6 +86,7 @@ const areaClipboardCopyData = (dl) => {
     return data.map(transpose);
 };
 ```
+
 So we'll start our `function` by keeping track of the `AREA_CLIPBOARD_COPY_SELECTIONS`
 and `AREA_CLIPBOARD_COPIED_DATA`.
 Next, we can generate the corresponding `textSelections` by splitting the lines with `\t`
@@ -82,6 +94,7 @@ and selections with `\n`.
 
 Finally, we write our generated text to the `navigator.clipboard` and update the
 styling. Don't worry, we'll define `updateAreaClipboardInteractionsStyle()` later.
+
 ```javascript
 const areaClipboardCopy = async (table, dl) => {
     AREA_CLIPBOARD_COPY_SELECTIONS = getSelectedAreas();
@@ -99,10 +112,11 @@ const areaClipboardCopy = async (table, dl) => {
     }
 };
 ```
+
 For our `areaClipboardCut()`, we can simply call `areaClipboardCopy()` prior to
 overwriting the data in the `DataModel` with `undefined`, clearing the selected region.
-
 Then we call `draw()` to ensure the data in the `table` reflects the cut.
+
 ```javascript
 const areaClipboardCut = async (table, dl, write) => {
     await areaClipboardCopy(table, dl);
@@ -116,14 +130,13 @@ const areaClipboardCut = async (table, dl, write) => {
     table.draw();
 };
 ```
+
 Our implementation of `areaClipboardPaste()` is a bit tricky as we'd like to cover a
 couple of use cases.
-
 If the user is copying multiple selections from our `table` and there are multiple
 areas selected in our `table` to paste to, then we'd like to paste the first copied
 selection to the first paste selection and the second copied selection to the second
 paste selection and so on...
-
 In the event that the end user is copying from a different spreadsheet, we'll need
 to parse the text on the `clipboard` and attempt to `write` the parsed content to our
 `table`.
@@ -132,18 +145,19 @@ If the `parsedData` is unusable, we can only try to write the `AREA_CLIPBOARD_CO
 We'll also `useLocalData` if it matches the what's been parsed from the `clipboard`.
 Otherwise, we know that the `data` on the `clipboard` came from outside of
 `<regular-table>`, and we should map it to each of the selected areas we're pasting to. 
-
 We'll want to keep track of the `AREA_CLIPBOARD_PASTE_SELECTIONS` to style the areas
 we paste to using the same structure as `AREA_CLIPBOARD_COPY_SELECTIONS`.
+
 ```javascript
 let AREA_CLIPBOARD_PASTE_SELECTIONS = [];
 ```
+
 We'll then duplicate the `data` collection to ensure we can paste into all of the
 currently selected areas and zip the collections - pairing the currently selected areas
 with copied data. We can then iterate through the zipped collection writing the data to
 for each of the selections and calculating the pasted areas' dimensions.
-
 Finally, we call `draw()` to force the `table` to update the `date` shown.
+
 ```javascript
 const areaClipboardPaste = async (table, write) => {
     const zip = (arr, ...arrs) => arr.map((val, i) => arrs.reduce((a, arr) => [...a, arr[i]], [val]));
@@ -173,9 +187,11 @@ const areaClipboardPaste = async (table, write) => {
     await table.draw();
 };
 ```
+
 Our implementation of `tryParseAreaClipboardText()` takes the current `clipboard`
 text and attempts to map it assuming that it's formatted similar to content copied
 from a spreadsheet.
+
 ```javascript
 async function tryParseAreaClipboardText() {
     try {
@@ -187,7 +203,9 @@ async function tryParseAreaClipboardText() {
     }
 }
 ```
+
 We'll also need a quick `function` to compare our `Array`s of data for `areaClipboardPaste()`.
+
 ```javascript
 function eqArray(a1, a2) {
     if (!Array.isArray(a1) || !Array.isArray(a2) || a1.length !== a2.length) return false;
@@ -200,8 +218,13 @@ function eqArray(a1, a2) {
     return true;
 }
 ```
+
 ## Styling
-Similar to other examples like `row_column_area_selection`, we will use a primary color scheme to show the selected areas and their overlap with areas that are being copied or have been pasted to.
+
+Similar to other examples like `row_column_area_selection`, we will use a primary
+color scheme to show the selected areas and their overlap with areas that are
+being copied or have been pasted to.
+
 ```css
 regular-table tbody tr td.mouse-selected-area {
     background-color: rgb(255, 0, 0, 0.25); /* red */
@@ -225,7 +248,9 @@ regular-table tbody tr td.mouse-selected-area.clipboard-copy-selected-area.clipb
     background-color: rgb(183, 65, 14, 0.33); /* rust */
 }
 ```
+
 Lets turn off the `user-select` style for this example too
+
 ```css
 regular-table tbody tr td {
     user-select: none;
@@ -237,7 +262,9 @@ regular-table thead tr th {
     user-select: none;
 }
 ```
+
 And outline the `td`s.
+
 ```css
 td {
     outline: none;
@@ -246,8 +273,11 @@ td {
     min-width: 22px;
 }
 ```
+
 ## `StyleListener`
+
 We'll need to add a `StyleListener` to `add` or `remove` the classes for copy and paste.
+
 ```javascript
 const AREA_CLIPBOARD_COPY_SELECTED_CLASS = "clipboard-copy-selected-area";
 const AREA_CLIPBOARD_PASTE_SELECTED_CLASS = "clipboard-paste-selected-area";
@@ -256,14 +286,15 @@ const addAreaClipboardInteractionsStyleListener = (table) => {
     table.addStyleListener(() => updateAreaClipboardInteractionsStyle(table));
 };
 ```
+
 We'll make the logic for updating the `classList` available via a `function` that
 can be called outside of the `StyleListener`, so that we can invoke it without forcing a
 `draw()` on the `table`.
-
 Basically, `updateAreaClipboardInteractionsStyle()` iterates through the `td`s on the
 screen removing the `AREA_CLIPBOARD_COPY_SELECTED_CLASS` and `AREA_CLIPBOARD_PASTE_SELECTED_CLASS`
 from each and then checks to see if the `MetaData` shows that it intersects a copied
 or pasted selection, reapplying the classes on a match.
+
 ```javascript
 const updateAreaClipboardInteractionsStyle = (table) => {
     const tds = table.querySelectorAll("tbody td");
@@ -285,8 +316,13 @@ const updateAreaClipboardInteractionsStyle = (table) => {
     }
 };
 ```
+
 ## Our `DataListener`
-Our `DataListener` generator uses some borrowed code from `two_billion_rows` and extends the `return`ed `object` with `allData` - exposed to enable our `write` `function`.
+
+Our `DataListener` generator uses some borrowed code from `two_billion_rows` and
+extends the `return`ed `object` with `allData` - exposed to enable our `write`
+`function`.
+
 ```javascript
 function generateDataListener(num_rows, num_columns) {
     const allData = range(0, num_columns, (x) => range(0, num_rows, (y) => `${x}, ${y}`));
@@ -300,12 +336,15 @@ function generateDataListener(num_rows, num_columns) {
     };
 }
 ```
+
 ## On `"load"`
+
 We will wire it all up on `"load"` by checking that the `table` exists on the `window`
 then creating and setting our `DataListener`. We need to make sure that we
 `addAreaMouseSelection()` and create a `write()` `function` for use in
-`addAreaClipboardInteractions()`, and then we can `addAreaClipboardInteractions()` and kick
-off a `draw()`.
+`addAreaClipboardInteractions()`, and then we can `addAreaClipboardInteractions()`
+and kick off a `draw()`.
+
 ```javascript
 window.addEventListener("load", () => {
     const table = window.areaClipboardInteractionsRegularTable;

--- a/examples/area_mouse_selection.md
+++ b/examples/area_mouse_selection.md
@@ -14,50 +14,54 @@ accessible on the window object using [`window.${id}`](https://stackoverflow.com
 
 Lets start by making the area selection behavior available via a single function,
 `addAreaMouseSelection()`, that takes a `<regular-table>` and applies our behavior.
-
 Mouse area selection is a complex feature composed of a few events interacting
 with some shared state. As users, we expect to left click a cell, hold the mouse
 button down, move the mouse to another cell and then release, resulting in a table
 showing the selected region.
-
 In order to record the selected area, we will need the location of the cell when
-the `"mousedown"` event is triggered and the location of the cell on `"mouseup"` which
-we will add as a coordinate pair to a collection of `MOUSE_SELECTED_AREAS`.
+the `"mousedown"` event is triggered and the location of the cell on `"mouseup"`
+which we will add as a coordinate pair to a collection of `MOUSE_SELECTED_AREAS`.
 By holding the `ctrlKey` or `metaKey` while making selections, 
 our users can make multiple selections show at once.
-
 Lets also add a `"mouseover"` `EventListener` to paint the selection as the user
 moves the mouse - showing the region that would be selected on `"mouseup"`.
-
 Finally, we'll need to ensure that the selection paints correctly as it scrolls
 in and out of the visible table using a `StyleListener` that we will define later.
 
 ```javascript
 let MOUSE_SELECTED_AREAS = [];
 
-const addAreaMouseSelection = (table) => {
+const MOUSE_SELECTED_AREA_CLASS = "mouse-selected-area";
+
+const addAreaMouseSelection = (table, {className = MOUSE_SELECTED_AREA_CLASS} = {}) => {
     table.addEventListener("mousedown", getMousedownListener(table));
-    table.addEventListener("mouseover", getMouseoverListener(table));
-    table.addEventListener("mouseup", getMouseupListener(table));
-    addAreaMouseSelectionStyleListener(table);
+    table.addEventListener("mouseover", getMouseoverListener(table, className));
+    table.addEventListener("mouseup", getMouseupListener(table, className));
+    addAreaMouseSelectionStyleListener(table, className);
     return table;
 };
 ```
+
 ## Listening to Mouse Events
 
-We will need to share the `CURRENT_MOUSEDOWN_COORDINATES` to do some checks in each mouse `EventListener`.
+We will need to share the `CURRENT_MOUSEDOWN_COORDINATES` to do some checks in
+each mouse `EventListener`.
 
 ```javascript
 let CURRENT_MOUSEDOWN_COORDINATES = {};
 ```
 
-Now for each of our mouse listeners, we'll need the `table` passed in from `addAreaMouseSelection()`,
-so we will define each as a higher-order function creating a closure and keeping
-the `table` argument available.
+Now for each of our mouse listeners, we'll need the `table` passed in from
+`addAreaMouseSelection()`, so we will define each as a higher-order function
+creating a closure and keeping the `table` argument available.
 
-First we can create a `"mousedown"` `EventListener` by calling `getMousedownListener()` with the table. The listener function `return`ed will look up the coordinates of the `event.target` using `getMeta()` and update the `CURRENT_MOUSEDOWN_COORDINATES`.
+First we can create a `"mousedown"` `EventListener` by calling
+`getMousedownListener()` with the table. The listener function `return`ed will
+look up the coordinates of the `event.target` using `getMeta()` and update the
+`CURRENT_MOUSEDOWN_COORDINATES`.
 
-It's also responsible for clearing the previous `MOUSE_SELECTED_AREAS` if the user isn't holding the `ctrl` or `metaKey`.
+It's also responsible for clearing the previous `MOUSE_SELECTED_AREAS` if the
+user isn't holding the `ctrl` or `metaKey`.
 
 ```javascript
 const getMousedownListener = (table) => (event) => {
@@ -71,11 +75,13 @@ const getMousedownListener = (table) => (event) => {
     }
 };
 ```
-The `EventListener` returned for `"mouseover"` first checks that a valid `CURRENT_MOUSEDOWN_COORDINATES`
-is set and then reapplies the cell selection with the `event.target`'s coordinates
- used to calculate the `potentialSelection`.
+
+The `EventListener` returned for `"mouseover"` first checks that a valid
+`CURRENT_MOUSEDOWN_COORDINATES` is set and then reapplies the cell selection with
+the `event.target`'s coordinates used to calculate the `potentialSelection`.
+
 ```javascript
-const getMouseoverListener = (table) => (event) => {
+const getMouseoverListener = (table, className) => (event) => {
     if (CURRENT_MOUSEDOWN_COORDINATES && CURRENT_MOUSEDOWN_COORDINATES.x !== undefined) {
         const meta = table.getMeta(event.target);
         if (meta && meta.x !== undefined && meta.y !== undefined) {
@@ -85,16 +91,19 @@ const getMouseoverListener = (table) => (event) => {
                 y0: Math.min(meta.y, CURRENT_MOUSEDOWN_COORDINATES.y),
                 y1: Math.max(meta.y, CURRENT_MOUSEDOWN_COORDINATES.y),
             };
-            reapplyMouseAreaSelections(table, MOUSE_SELECTED_AREAS.concat([potentialSelection]));
+            reapplyMouseAreaSelections(table, className, MOUSE_SELECTED_AREAS.concat([potentialSelection]));
         }
     }
 };
 ```
-Similarly, on `"mouseup"` we will need to capture the coordinates of the `event.target` and `push()` this new selection into `MOUSE_SELECTED_AREAS`.
 
-With our `MOUSE_SELECTED_AREAS` up to date, we will reapply the selection then clear the `CURRENT_MOUSEDOWN_COORDINATES`.
+Similarly, on `"mouseup"` we will need to capture the coordinates of the
+`event.target` and `push()` this new selection into `MOUSE_SELECTED_AREAS`.
+With our `MOUSE_SELECTED_AREAS` up to date, we will reapply the selection then
+clear the `CURRENT_MOUSEDOWN_COORDINATES`.
+
 ```javascript
-const getMouseupListener = (table) => (event) => {
+const getMouseupListener = (table, className) => (event) => {
     const meta = table.getMeta(event.target);
     if (CURRENT_MOUSEDOWN_COORDINATES && CURRENT_MOUSEDOWN_COORDINATES.x !== undefined && meta.x !== undefined && meta.y !== undefined) {
         const selection = {
@@ -104,83 +113,115 @@ const getMouseupListener = (table) => (event) => {
             y1: Math.max(meta.y, CURRENT_MOUSEDOWN_COORDINATES.y),
         };
         MOUSE_SELECTED_AREAS.push(selection);
-        reapplyMouseAreaSelections(table);
+        reapplyMouseAreaSelections(table, className);
     }
     CURRENT_MOUSEDOWN_COORDINATES = {};
 };
 ```
-Our `reapplyMouseAreaSelections()` will simply `remove()` the `MOUSE_SELECTED_AREA_CLASS`
-from all `td`s in the `table` and then iterate over the `areaSelections` reapplying the
-`MOUSE_SELECTED_AREA_CLASS`.
-```javascript
-const MOUSE_SELECTED_AREA_CLASS = "mouse-selected-area";
 
-const reapplyMouseAreaSelections = (table, areaSelections = MOUSE_SELECTED_AREAS) => {
+Our `reapplyMouseAreaSelections()` will simply `remove()` the `className`
+from all `td`s in the `table` and then iterate over the `areaSelections` reapplying the
+`className`.
+
+```javascript
+const reapplyMouseAreaSelections = (table, className, areaSelections = MOUSE_SELECTED_AREAS) => {
     const tds = table.querySelectorAll("tbody td");
     for (const td of tds) {
-        td.classList.remove(MOUSE_SELECTED_AREA_CLASS);
+        td.classList.remove(className);
     }
 
     for (const as of areaSelections) {
-        applyMouseAreaSelection(table, as);
+        applyMouseAreaSelection(table, as, className);
     }
 };
 ```
+
 Much like our `MetaData` `object`, we will use `x0` and `y0` to describe the upper
 left corner and `x1` and `y1` for the lower right corner in the body of `applyMouseAreaSelection()`.
-We can iterate through the `td`s in the `table` adding the `MOUSE_SELECTED_AREA_CLASS`
+We can iterate through the `td`s in the `table` adding the `className`
 if the `td`'s metadata falls within the rectangular region defined by those coordinates.
+
 ```javascript
-const applyMouseAreaSelection = (table, {x0, x1, y0, y1}) => {
+const applyMouseAreaSelection = (table, {x0, x1, y0, y1}, className) => {
     const tds = table.querySelectorAll("tbody td");
     if (x0 !== undefined && y0 !== undefined && x1 !== undefined && y1 !== undefined) {
         for (const td of tds) {
             const meta = table.getMeta(td);
             if (x0 <= meta.x && meta.x <= x1) {
                 if (y0 <= meta.y && meta.y <= y1) {
-                    td.classList.add(MOUSE_SELECTED_AREA_CLASS);
+                    td.classList.add(className);
                 }
             }
         }
     }
 };
 ```
+
 ## Styling
+
 By default the `user-select` style is applied, lets get rid of it for our `td`s.
+
 ```css
 regular-table tbody tr td {
     user-select: none;
 }
 ```
+
 And we'll need to style the selection to make it look nice for the end user.
+
 ```css
 regular-table tbody tr td.mouse-selected-area {
-    background-color: #ffbbbb; /* red */
+    background-color: #2771A8;
+    color: white;
 }
 ```
+
 ## `StyleListener`
+
 And we can't forget about our `StyleListener` to ensure that the `table` reapplies
 the selection as we scroll the grid - otherwise the selection will follow us around.
+
 ```javascript
-const addAreaMouseSelectionStyleListener = (table) => {
-    table.addStyleListener(() => reapplyMouseAreaSelections(table));
+const addAreaMouseSelectionStyleListener = (table, className) => {
+    table.addStyleListener(() => reapplyMouseAreaSelections(table, className));
 };
 ```
-## `init()`
-We can add an `init()` to this example to wire up the `DataListener` borrowed from
-`two_billion_rows` and then we simply addAreaMouseSelection() to the `table` and `draw()`.
 
+## on `"load"`
+
+We can load `defaultRowSelections()` to this example and wire up the `DataListener`
+borrowed from `two_billion_rows` and then we simply `addAreaMouseSelection()` to
+the `table` and `draw()`.
 All of this will be invoked on `"load"`.
-```javascript
-function init() {
+
+```html
+<script>
+function defaultRowSelections() {
+    MOUSE_SELECTED_AREAS = [
+        {x0: 5, x1: 7, y0: 7, y1: 11},
+        {x0: 1, x1: 3, y0: 16, y1: 22},
+        {x0: 7, x1: 8, y0: 15, y1: 18},
+    ];
+}
+
+window.addEventListener("load", () => {
     const table = window.areaMouseSelectionRegularTable;
     if (table) {
         table.setDataListener(window.dataListener);
-        addAreaMouseSelection(table).draw();
+        defaultRowSelections();
+        addAreaMouseSelection(table)
+        table.draw();
     }
-}
+});
+</script>
+```
 
-window.addEventListener("load", () => init());
+## Appendix (Exports)
+
+This is the public function you can use.
+
+```javascript
+exports.addAreaMouseSelection = addAreaMouseSelection;
 ```
 
 ## Appendix (Dependencies)
@@ -196,4 +237,8 @@ Borrow a data model from `two_billion_rows`.
 
 ```html
 <script src="/dist/examples/two_billion_rows.js"></script>
+```
+
+```block
+license: apache-2.0
 ```

--- a/examples/row_mouse_selection.md
+++ b/examples/row_mouse_selection.md
@@ -416,15 +416,36 @@ function generateDataListener(num_rows, num_columns) {
 Now to kick off our example on `"load"` by adding an `EvenListener` that will set
 our `table`'s `DataListener` from `generateDataListener()`,
 `addRowMouseSelection()` and make an initial call to `draw()`.
+We will use `defaultRowSelection()` to show a few selections by default on load.
 
 ```html
 <script>
+function defaultRowSelection () {
+    MOUSE_SELECTED_ROWS = [
+        {
+            row_header: ["Group 10", "Row 11"],
+            y0: 11,
+            y1: 11,
+        }, {
+            row_header: ["Group 10", "Row 15"],
+            y0: 14,
+            y1: 15,
+        }, {
+            row_header: ["Group 10", "Row 18"],
+            y0: 17,
+            y1: 18,
+        }
+    ];
+}
+
 window.addEventListener("load", () => {
     const table = window.rowMouseSelectionRegularTable;
     if (table) {
         const dl = generateDataListener(200, 50);
         table.setDataListener(dl);
-        addRowMouseSelection(table, dl).draw();
+        addRowMouseSelection(table, dl);
+        defaultRowSelection();
+        table.draw();
     }
 });
 </script>

--- a/examples/row_mouse_selection.md
+++ b/examples/row_mouse_selection.md
@@ -261,7 +261,8 @@ Let's style our `mouse-selected-row` - in this example we'll use a light yellow.
 
 ```css
 regular-table tbody tr td.mouse-selected-row, regular-table tr th.mouse-selected-row {
-    background-color: #ffffbb; /* yellow */
+    background-color: #2771A8;
+    color: white;
 }
 ```
 

--- a/examples/row_stripes.md
+++ b/examples/row_stripes.md
@@ -1,8 +1,7 @@
-# Striped
+# Row Stripes
 
 An example of adding stripes to a [`regular-table`](https://github.com/jpmorganchase/regular-table)
 by setting the each `tr`s `background-color`.
-
 Lets start by adding a `<regular-table>` to the page with an `id` that will
 be accessible on the window object using [`window.${id}`](https://stackoverflow.com/questions/18713272/why-do-dom-elements-exist-as-properties-on-the-window-object).
 
@@ -17,11 +16,11 @@ the style on `tr:nth-child(odd)` and `tr:nth-child(even)`.
 
 ```css
 .stripes tbody tr:nth-child(odd) td { 
-    background-color: #ddd;
+    background-color: #EAEDEF;
 }
 
 .stripes tbody tr:nth-child(even) td {
-    background-color: #eee;
+    background-color: white;
 }
 ```
 
@@ -29,17 +28,16 @@ However by simply adding stripes to the rows, the top-most row will always show
 with the darker `background-color: #ddd`, and the next row will retain its
 even, `background-color: #eee`, style as the user scrolls - repeating for each
 row and making the striping look inconsistent.
-
 We're going to add the `.reverse-stripes` class for use in our 
 `alternateStripes()` function that applies a `StyleListener`.
 
 ```css
 .reverse-stripes tbody tr:nth-child(odd) td {
-    background-color: #eee;
+    background-color: white;
 }
 
 .reverse-stripes tbody tr:nth-child(even) td {
-    background-color: #ddd;
+    background-color: #EAEDEF;
 }
 ```
 
@@ -48,34 +46,31 @@ We're going to add the `.reverse-stripes` class for use in our
 Adding a `StyleListener` to the `<regular-table>` in our `alternateStripes()`
 function will ensure that the odd and even styling will alternate depending
 on the oddness/evenness of the top-most row.
-
 We can `getMeta()` from the table and add/remove our `.stipes` and 
 `.reverse-stripes` classes based on the evenness of the `meta.y0` or the `y` 
 index of the viewport origin.
 
 ```javascript
+const EVEN_STRIPE_CLASS = "stripes";
+const ODD_STRIPE_CLASS = "reverse-stripes";
 
-const STRIPES_CLASS = "stripes";
-const REVERSE_STRIPES_CLASS = "reverse-stripes";
-
-const alternateStripes = (table) => {
+const alternateStripes = (table, {evenStripeClassName = EVEN_STRIPE_CLASS, oddStripeClassName = ODD_STRIPE_CLASS} = {}) => {
     table.addStyleListener(() => {
         const tds = table.querySelectorAll("tbody tr:nth-of-type(1) td");
         const meta = table.getMeta(tds[0]);
 
         if (meta) {
             if (meta.y0 % 2 === 0) {
-                table.classList.remove(REVERSE_STRIPES_CLASS);
-                table.classList.add(STRIPES_CLASS);
+                table.classList.remove(oddStripeClassName);
+                table.classList.add(evenStripeClassName);
             } else {
-                table.classList.remove(STRIPES_CLASS);
-                table.classList.add(REVERSE_STRIPES_CLASS);
+                table.classList.remove(evenStripeClassName);
+                table.classList.add(oddStripeClassName);
             }
         }
     });
     return table;
 };
-
 ```
 
 ## Virtual Data Model
@@ -100,24 +95,31 @@ function generateDataListener(num_rows, num_columns) {
 }
 ```
 
-Lets set up an `init()` to use `generateDataListener()` to create a 10k row
-data set and call `setDataListener()` with it.
+Lets set up by using `generateDataListener()` to create a 10k row data set and
+call `setDataListener()` with it.
 Next we'll call our `alternateStripes()` function passing in the `#stripedRegularTable`
 and then invoke `draw()` - checking that the `#stripedRegularTable` exists first.
-
 All of this will be invoked on `"load"`.
 
-```javascript
-function init() {
+```html
+<script>
+window.addEventListener("load", () => {
     if (window.stripedRegularTable) {
         const dataListener = generateDataListener(10000, 50);
         window.stripedRegularTable.setDataListener(dataListener);
         alternateStripes(window.stripedRegularTable);
         window.stripedRegularTable.draw();
     }
-}
+});
+</script>
+```
 
-window.addEventListener("load", () => init());
+## Appendix (Exports)
+
+This is the public function you can use.
+
+```javascript
+exports.alternateStripes = alternateStripes;
 ```
 
 ## Appendix (Dependencies)
@@ -133,4 +135,8 @@ Borrow utility functions from the `two_billion_rows` example.
 
 ```html
 <script src="/dist/examples/two_billion_rows.js"></script>
+```
+
+```block
+license: apache-2.0
 ```

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -11,6 +11,7 @@ const hashes = {
     spreadsheet: "3e0e3d6f8bf8b47294a7847b402b55fb",
     row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
     row_stripes: "aaaaaaaaaaaaaaaaaa",
+    area_mouse_selection: "bbbbbbbbbbbbbbbbbb",
 };
 
 for (const file in hashes) {

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -9,6 +9,7 @@ const hashes = {
     minesweeper: "96a9ed60d0250f7d3187c0fed5f5b78c",
     file_browser: "a7b7588c899e3953dd8580e81c51b3f9",
     spreadsheet: "3e0e3d6f8bf8b47294a7847b402b55fb",
+    row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
 };
 
 for (const file in hashes) {

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -12,6 +12,7 @@ const hashes = {
     row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
     row_stripes: "aaaaaaaaaaaaaaaaaa",
     area_mouse_selection: "bbbbbbbbbbbbbbbbbb",
+    column_mouse_selection: "cccccccccccccccccc",
 };
 
 for (const file in hashes) {

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -10,6 +10,7 @@ const hashes = {
     file_browser: "a7b7588c899e3953dd8580e81c51b3f9",
     spreadsheet: "3e0e3d6f8bf8b47294a7847b402b55fb",
     row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
+    row_stripes: "aaaaaaaaaaaaaaaaaa",
 };
 
 for (const file in hashes) {
@@ -18,14 +19,26 @@ for (const file in hashes) {
         if (fs.existsSync(`dist/${hashes[file]}`)) {
             console.log(`dist/${hashes[file]} exists, skipping checkout`);
         } else {
-            child_process.execSync(`git clone https://gist.github.com/${hashes[file]}.git dist/${hashes[file]}`);
+            try {
+                child_process.execSync(`git clone https://gist.github.com/${hashes[file]}.git dist/${hashes[file]}`);
+            } catch (e) {
+                console.error(`Failed to clone creating a local git repo ${hashes[file]}`);
+                fs.mkdirSync(`dist/${hashes[file]}`);
+            }
         }
 
         // Run literally for this project
-        console.log(child_process.execSync(`yarn literally --format block --output dist/${hashes[file]} examples/${file}.md`).toString());
+        console.log(child_process.execSync(`yarn literally --screenshot --format block --output dist/${hashes[file]} examples/${file}.md`).toString());
 
         // Update git
         process.chdir(`dist/${hashes[file]}`);
+        if (!fs.existsSync("./.git")) {
+            console.log(child_process.execSync(`git init`).toString());
+            console.log(child_process.execSync(`touch README.md`).toString());
+            console.log(child_process.execSync(`git add README.md`).toString());
+            console.log(child_process.execSync(`git commit -m "First Commit"`).toString());
+        }
+
         child_process.execSync(`git add thumbnail.png preview.png index.html .block README.md`);
         console.log(child_process.execSync(`git status`).toString());
         console.log(child_process.execSync(`git commit -am"Auto update via sync_gist" --amend`).toString());

--- a/test/examples/column_mouse_selection/selecting_column_headers.test.js
+++ b/test/examples/column_mouse_selection/selecting_column_headers.test.js
@@ -25,8 +25,8 @@ describe("column_mouse_selection.html", () => {
     });
 
     describe("initial view", () => {
-        test("includes no selection", async () => {
-            expect(await selectedColumns()).toEqual([]);
+        test("includes defaults", async () => {
+            expect(await selectedColumns()).toEqual(["Column 6", "Column 8", "Column 9"]);
         });
     });
 
@@ -36,7 +36,7 @@ describe("column_mouse_selection.html", () => {
                 const ths = await page.$$("regular-table thead th");
 
                 await page.evaluate(async (th) => {
-                    const event = new MouseEvent("click", {bubbles: true});
+                    const event = new MouseEvent("click", { bubbles: true });
                     th.dispatchEvent(event);
                 }, ths[0]);
 
@@ -53,7 +53,7 @@ describe("column_mouse_selection.html", () => {
 
             test("includes the group and the columns", async () => {
                 await page.evaluate(async (th) => {
-                    const event = new MouseEvent("click", {bubbles: true});
+                    const event = new MouseEvent("click", { bubbles: true });
                     th.dispatchEvent(event);
                 }, ths[1]);
 
@@ -64,7 +64,7 @@ describe("column_mouse_selection.html", () => {
                 expect(await selectedColumns()).toEqual(["Group 0", "Column 0", "Column 1", "Column 2", "Column 3", "Column 4", "Column 5", "Column 6", "Column 7", "Column 8", "Column 9"]);
 
                 await page.evaluate(async (th) => {
-                    const event = new MouseEvent("click", {bubbles: true, ctrlKey: true});
+                    const event = new MouseEvent("click", { bubbles: true, ctrlKey: true });
                     th.dispatchEvent(event);
                 }, ths[9]);
 

--- a/test/examples/column_mouse_selection/selecting_one_column_range.test.js
+++ b/test/examples/column_mouse_selection/selecting_one_column_range.test.js
@@ -33,12 +33,12 @@ describe("column_mouse_selection.html", () => {
 
         test("selects the columns' headers and cells", async () => {
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true });
                 th.dispatchEvent(event);
             }, ths[9]);
 
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                 th.dispatchEvent(event);
             }, ths[11]);
 

--- a/test/examples/column_mouse_selection/splitting_one_column_range.test.js
+++ b/test/examples/column_mouse_selection/splitting_one_column_range.test.js
@@ -33,19 +33,19 @@ describe("column_mouse_selection.html", () => {
 
         test("selects the columns' headers and cells", async () => {
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                 th.dispatchEvent(event);
             }, ths[17]);
 
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                 th.dispatchEvent(event);
             }, ths[13]);
 
             await page.waitFor("regular-table td.mouse-selected-column");
             expect(await selectedColumns()).toEqual(["Column 6", "Column 7", "Column 8", "Column 9", "Column 10"]);
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, ctrlKey: true});
+                const event = new MouseEvent("click", { bubbles: true, ctrlKey: true });
                 th.dispatchEvent(event);
             }, ths[15]);
 

--- a/test/examples/row_mouse_selection/selecting_one_row_range.test.js
+++ b/test/examples/row_mouse_selection/selecting_one_row_range.test.js
@@ -28,7 +28,7 @@ describe("row_mouse_selection.html", () => {
         test("selects the rows' headers and cells", async () => {
             const rowHeader1 = await page.$("regular-table tbody tr:nth-of-type(2) th");
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true });
                 th.dispatchEvent(event);
             }, rowHeader1);
 

--- a/test/examples/row_mouse_selection/splitting_one_row_range.test.js
+++ b/test/examples/row_mouse_selection/splitting_one_row_range.test.js
@@ -28,7 +28,7 @@ describe("row_mouse_selection.html", () => {
         test("selects the rows' headers and cells", async () => {
             const rowHeader1 = await page.$("regular-table tbody tr:nth-of-type(2) th");
             await page.evaluate(async (th) => {
-                const event = new MouseEvent("click", {bubbles: true, shiftKey: true});
+                const event = new MouseEvent("click", { bubbles: true });
                 th.dispatchEvent(event);
             }, rowHeader1);
 

--- a/test/examples/row_stripes.test.js
+++ b/test/examples/row_stripes.test.js
@@ -8,10 +8,10 @@
  *
  */
 
-describe("striped.html", () => {
+describe("row_stripes.html", () => {
     beforeAll(async () => {
         await page.setViewport({width: 200, height: 100});
-        await page.goto("http://localhost:8081/dist/examples/striped.html");
+        await page.goto("http://localhost:8081/dist/examples/row_stripes.html");
         await page.waitFor("regular-table table tbody tr td");
     });
 
@@ -19,11 +19,11 @@ describe("striped.html", () => {
         test("row style alternates", async () => {
             const tds1 = await page.$$("regular-table tbody tr:nth-of-type(1) td");
             const backgroundColor1 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds1[0]);
-            expect(backgroundColor1).toEqual("rgb(221, 221, 221)");
+            expect(backgroundColor1).toEqual("rgb(234, 237, 239)");
 
             const tds2 = await page.$$("regular-table tbody tr:nth-of-type(2) td");
             const backgroundColor2 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds2[0]);
-            expect(backgroundColor2).toEqual("rgb(238, 238, 238)");
+            expect(backgroundColor2).toEqual("rgb(255, 255, 255)");
         });
     });
 
@@ -39,11 +39,11 @@ describe("striped.html", () => {
         test("row style alternates in reverse", async () => {
             const tds1 = await page.$$("regular-table tbody tr:nth-of-type(1) td");
             const backgroundColor1 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds1[0]);
-            expect(backgroundColor1).toEqual("rgb(238, 238, 238)");
+            expect(backgroundColor1).toEqual("rgb(255, 255, 255)");
 
             const tds2 = await page.$$("regular-table tbody tr:nth-of-type(2) td");
             const backgroundColor2 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds2[0]);
-            expect(backgroundColor2).toEqual("rgb(221, 221, 221)");
+            expect(backgroundColor2).toEqual("rgb(234, 237, 239)");
         });
     });
 });


### PR DESCRIPTION
Export the `addColumnMouseSelection()` function and make column selection available as a blocks example.

![preview](https://user-images.githubusercontent.com/61175/110864482-315cd100-8290-11eb-83fe-4d09259ab49c.png)
