### PR TITLE
Return an unsubscribe function from `addStyleListener`

### DIFF
--- a/examples/row_stripes.md
+++ b/examples/row_stripes.md
@@ -28,7 +28,7 @@ However by simply adding stripes to the rows, the top-most row will always show
 with the darker `background-color: #ddd`, and the next row will retain its
 even, `background-color: #eee`, style as the user scrolls - repeating for each
 row and making the striping look inconsistent.
-We're going to add the `.reverse-stripes` class for use in our 
+We're going to add the `.reverse-stripes` class for use in our
 `alternateStripes()` function that applies a `StyleListener`.
 
 ```css
@@ -44,18 +44,21 @@ We're going to add the `.reverse-stripes` class for use in our
 ## Adding a `StyleListener` with `alternateStripes()`
 
 Adding a `StyleListener` to the `<regular-table>` in our `alternateStripes()`
-function will ensure that the odd and even styling will alternate depending
-on the oddness/evenness of the top-most row.
-We can `getMeta()` from the table and add/remove our `.stipes` and 
-`.reverse-stripes` classes based on the evenness of the `meta.y0` or the `y` 
-index of the viewport origin.
+function will ensure that the odd and even styling will alternate depending on
+the oddness/evenness of the top-most row. We can `getMeta()` from the table and
+add/remove our `.stipes` and `.reverse-stripes` classes based on the evenness of
+the `meta.y0` or the `y` index of the viewport origin. We will also make sure to
+return a function that removes the style listener (using the return value of
+`addStyleListener()`) and the attached classes for cleanup purposes. Once this
+function is called, the stripes will be gone and no longer get applied as the
+user scrolls - this is because the style listener has been removed.
 
 ```javascript
 const EVEN_STRIPE_CLASS = "stripes";
 const ODD_STRIPE_CLASS = "reverse-stripes";
 
 const alternateStripes = (table, {evenStripeClassName = EVEN_STRIPE_CLASS, oddStripeClassName = ODD_STRIPE_CLASS} = {}) => {
-    table.addStyleListener(() => {
+    const removeStyleListener = table.addStyleListener(() => {
         const tds = table.querySelectorAll("tbody tr:nth-of-type(1) td");
         const meta = table.getMeta(tds[0]);
 
@@ -69,7 +72,12 @@ const alternateStripes = (table, {evenStripeClassName = EVEN_STRIPE_CLASS, oddSt
             }
         }
     });
-    return table;
+
+    return () => {
+        removeStyleListener();
+        table.classList.remove(evenStripeClassName);
+        table.classList.remove(oddStripeClassName);
+    };
 };
 ```
 
@@ -107,7 +115,7 @@ window.addEventListener("load", () => {
     if (window.stripedRegularTable) {
         const dataListener = generateDataListener(10000, 50);
         window.stripedRegularTable.setDataListener(dataListener);
-        alternateStripes(window.stripedRegularTable);
+        window.removeStripes = alternateStripes(window.stripedRegularTable);
         window.stripedRegularTable.draw();
     }
 });
@@ -128,7 +136,7 @@ The usual suspects.
 
 ```html
 <script src="/dist/umd/regular-table.js"></script>
-<link rel='stylesheet' href="/dist/css/material.css">
+<link rel="stylesheet" href="/dist/css/material.css" />
 ```
 
 Borrow utility functions from the `two_billion_rows` example.

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,17 +29,19 @@ declare module 'regular-table' {
          * @memberof RegularTableElement
          * @param {function({detail: RegularTableElement}): void} styleListener - A
          * (possibly async) function that styles the inner <table>.
-         * @returns {number} The index of the added listener.
+         * @returns {function(): void} A function to remove this style listener.
          * @example
-         * table.addStyleListener(() => {
+         * const unsubscribe = table.addStyleListener(() => {
          *     for (const td of table.querySelectorAll("td")) {
          *         td.setAttribute("contenteditable", true);
          *     }
          * });
+         *
+         * setTimeout(() => {
+         *     unsubscribe();
+         * }, 1000);
          */
-        addStyleListener(styleListener: (arg0: {
-                detail: RegularTableElement;
-        }) => void): number;
+        addStyleListener(styleListener: (arg0: {detail: RegularTableElement}) => void): () => void;
 
         /**
          * Draws this virtual panel, given an object of render options that allow

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -349,7 +349,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             let last_cells;
             for await (last_cells of this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns)) {
                 this._is_styling = true;
-                for (const callback of this._style_callbacks.values()) {
+                const callbacks = this._style_callbacks;
+                for (const callback of callbacks) {
                     await callback({detail: this});
                 }
                 this._is_styling = false;

--- a/test/examples/row_stripes.test.js
+++ b/test/examples/row_stripes.test.js
@@ -46,4 +46,25 @@ describe("row_stripes.html", () => {
             expect(backgroundColor2).toEqual("rgb(234, 237, 239)");
         });
     });
+
+    test("removes style listener", async () => {
+        await page.evaluate(() => {
+            window.removeStripes();
+        });
+
+        const table = await page.$("regular-table");
+        await page.evaluate(async (table) => {
+            // Scroll a few pages down to verify that the style listener wasn't called
+            table.scrollBy(0, window.innerHeight * 10);
+            await table.draw();
+        }, table);
+
+        const tds1 = await page.$$("regular-table tbody tr:nth-of-type(1) td");
+        const backgroundColor1 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds1[0]);
+        expect(backgroundColor1).toEqual("rgba(0, 0, 0, 0)");
+
+        const tds2 = await page.$$("regular-table tbody tr:nth-of-type(2) td");
+        const backgroundColor2 = await page.evaluate((td) => getComputedStyle(td).getPropertyValue("background-color"), tds2[0]);
+        expect(backgroundColor2).toEqual("rgba(0, 0, 0, 0)");
+    });
 });


### PR DESCRIPTION
This is a breaking change because it changes the return value of `addStyleListener`. That being said, the return value wasn't particularly useful because there was no public API to remove subscribed listeners.