### PR TITLE
Add 'virtual_mode' optional argument to `setDataListener()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,24 @@ scroll, more data will be fetched from `getDataSlice()`, and parts of the
 </regular-table>
 ```
 
+
+#### `virtual_mode` Option
+
+`regular-table` supports four modes of virtual scrolling, which can be
+configured via the `virtual_mode` optional argument.  Note that using a
+`virtual_mode` other than the default `"both"` will render the _entire_
+`<table>` along the non-virtual axis(es), and may cause rendering performance
+degradation.
+
+* "both" (default) virtualizes scrolling on both axes.
+* "vertical" only virtualizes vertical (y) scrolling.
+* "horizontal" only virtualizes horizontal (x) scrolling.
+* "none" disable all scroll virtualization.
+
+```javascript
+table.setDataListener(listener, {virtual_mode: "vertical"})
+```
+
 ### Column and Row Headers
 
 `regular-table` can also generate Hierarchial Row and Column Headers, using

--- a/examples/perspective.md
+++ b/examples/perspective.md
@@ -485,6 +485,11 @@ exports.configureRegularTable = configureRegularTable;
 ## CSS
 
 ```css
+html,
+body {
+    overflow: hidden;
+}
+
 regular-table table {
     user-select: none;
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "jest-puppeteer-docker": "^1.4.2",
         "jsdoc-to-markdown": "^6.0.1",
         "less": "^3.9.0",
-        "literally-cli": "^0.0.7",
+        "literally-cli": "=0.0.7",
         "marked-ast-markdown": "^2.1.0",
         "npm-run-all": "^4.1.3",
         "prettier": "^2.0.5",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -74,11 +74,13 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * @param {*} event
      */
     _on_mousewheel(event) {
-        if (this._virtual_scrolling_disabled) {
+        if (!window.safari) {
+            // **** Apple
             return;
         }
+
         const {clientWidth, clientHeight, scrollTop, scrollLeft, scrollHeight} = this;
-        if ((event.deltaY > 0 && scrollTop + clientHeight < scrollHeight) || (event.deltaY < 0 && scrollTop > 0) || event.deltaY === 0) {
+        if ((event.deltaY > 0 && scrollTop + clientHeight >= scrollHeight) || (event.deltaY < 0 && scrollTop <= 0)) {
             event.preventDefault();
             event.returnValue = false;
             const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - clientHeight);
@@ -102,9 +104,6 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
      * @returns
      */
     _on_touchmove(event) {
-        if (this._virtual_scrolling_disabled) {
-            return;
-        }
         event.preventDefault();
         event.returnValue = false;
         const {clientWidth, clientHeight, scrollTop, scrollLeft} = this;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -13,6 +13,8 @@ import {RegularTableViewModel} from "./table";
 import {RegularViewEventModel} from "./events";
 import {get_draw_fps} from "./utils";
 
+const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"];
+
 /**
  * The `<regular-table>` custom element.
  *
@@ -254,6 +256,10 @@ class RegularTableElement extends RegularViewEventModel {
      * `dataListener` is called by to request a rectangular section of data
      * for a virtual viewport, (x0, y0, x1, y1), and returns a `DataReponse`
      * object.
+     * @param {Options} options.virtual_mode
+     * The `virtual_mode` options flag may be one of "both", "horizontal",
+     * "vertical", or "none" indicating which dimensions of the table should be
+     * virtualized (vs. rendering completely).
      * @example
      * table.setDataListener((x0, y0, x1, y1) => {
      *     return {
@@ -263,15 +269,18 @@ class RegularTableElement extends RegularViewEventModel {
      *     };
      * })
      */
-    setDataListener(dataListener) {
+    setDataListener(dataListener, {virtual_mode = "both"} = {}) {
         let schema = {};
         let config = {
             row_pivots: [],
             column_pivots: [],
         };
 
+        console.assert(VIRTUAL_MODES.indexOf(virtual_mode) > -1, `Unknown virtual_mode ${virtual_mode};  valid options are "both" (default), "horizontal", "vertical" or "none"`);
+        this._virtual_mode = virtual_mode;
         this._invalid_schema = true;
         this._view_cache = {view: dataListener, config, schema};
+        this._setup_virtual_scroll();
     }
 }
 

--- a/src/less/container.less
+++ b/src/less/container.less
@@ -15,6 +15,9 @@
     right: 0px;
     bottom: 0px;
     overflow: scroll;
+    overflow-anchor: none;
+    overscroll-behavior: none;
+    -webkit-overflow-scrolling: touch;
 }
 
 div.rt-virtual-panel {
@@ -25,10 +28,12 @@ div.rt-virtual-panel {
     pointer-events: none;
 }
 
+// https://stackoverflow.com/questions/44567125/position-sticky-scroll-bouncing-when-combined-with-javascript-height-adjustme
+// https://bugs.chromium.org/p/chromium/issues/detail?id=734461
+
 div.rt-scroll-table-clip {
     position: sticky;
-    top: 0;
-    left: 0;
+    overflow-anchor: none; 
     width: 100%;
     height: 100%;
 }
@@ -42,4 +47,5 @@ div.rt-tree-container {
 slot {
     position: absolute;
     overflow: hidden;
+    overflow-anchor: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,7 +5269,7 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-literally-cli@^0.0.7:
+literally-cli@=0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/literally-cli/-/literally-cli-0.0.7.tgz#221ef9e96c9cbea9de618106a0db5a798ab67599"
   integrity sha512-HpLCAe7VH+1mn4VznmZntWqNLsWpSf7lZSbTkaSbeah7bDT199rQ4Rt8Oud1Rnmw3BzLF8lFWOY3QQTmRd1mgw==


### PR DESCRIPTION
Adds an optional argument `virtual_mode` to the `setDataListener()` method.

```javascript
table.setDataListener(listener, {virtual_mode: "vertical"})
```

There are four virtual modes supported, including the previous (now default) behavior `"both"`.  The three new values each disable one or both virtual scroll axes:

* "both" (default) virtualizes scrolling on both axes.
* "vertical" only virtualizes vertical (y) scrolling.
* "horizontal" only virtualizes horizontal (x) scrolling.
* "none" disable all scroll virtualization.

Note that using a `virtual_mode` other than the default `"both"` will render the _entire_ `<table>` along the non-virtual axis(es), and may cause rendering performance degradation.



