### PR TITLE
Replace unsupported `className` prop with `class` in TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -356,7 +356,9 @@ declare module 'regular-table' {
     global {
         namespace JSX {
             interface IntrinsicElements {
-                "regular-table": DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+                "regular-table": Omit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, "className"> & {
+                    class?: string;
+                };
             }
         }
 


### PR DESCRIPTION
See https://reactjs.org/docs/web-components.html#using-web-components-in-react

Although this change can be viewed as breaking, I wouldn't personally call it such - if you pass `className`, then the class doesn't get applied. This is a bug fix in my opinion, and it allows consumers to correctly pass `class` prop.