### PR TITLE
Fix column group resize

### DIFF
--- a/features/literally.config.js
+++ b/features/literally.config.js
@@ -8,6 +8,10 @@ module.exports = {
     retarget: [
         {rule: /\/node_modules\//gm, value: "https://cdn.jsdelivr.net/npm/"},
         {
+            rule: /\.\/.+?\"/gm,
+            value: `./index.js"`,
+        },
+        {
             rule: /\/dist\//gm,
             value: `https://cdn.jsdelivr.net/npm/regular-table@${pkg.version}/dist/`,
         },

--- a/scripts/sync_gist.js
+++ b/scripts/sync_gist.js
@@ -12,10 +12,10 @@ compile("examples", {
 });
 
 compile("features", {
-    // row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
-    // row_stripes: "4157245997d92219d73ae43c25f29781",
+    row_mouse_selection: "f880c45f68ba062fd53e39fe13615d6d",
+    row_stripes: "4157245997d92219d73ae43c25f29781",
     area_mouse_selection: "4ac513f103a3bcef7b5442f52d9c6072",
-    // column_mouse_selection: "e89234de558575cdd92bfd111f224895",
+    column_mouse_selection: "e89234de558575cdd92bfd111f224895",
 });
 
 function compile(name, hashes) {

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -121,7 +121,7 @@ export class RegularTableViewModel {
                 first_col,
             };
             const size_key = _virtual_x + x0;
-            cont_body = this.body.draw(container_height, column_state, {...view_state, x0: 0}, true, undefined, undefined, size_key, _virtual_x);
+            cont_body = this.body.draw(container_height, column_state, {...view_state, x0: 0}, true, undefined, undefined, size_key);
             const cont_heads = [];
             for (let i = 0; i < view_cache.config.row_pivots.length; i++) {
                 cont_heads.push(this.header.draw(column_name, Array(view_cache.config.column_pivots.length + 1).fill(""), 1, undefined, i, x0, i));
@@ -166,7 +166,7 @@ export class RegularTableViewModel {
                 const x = dcidx + x0;
                 const size_key = _virtual_x + x0;
                 const cont_head = this.header.draw(undefined, column_name, undefined, x, size_key, x0, _virtual_x);
-                cont_body = this.body.draw(container_height, column_state, view_state, false, x, x0, size_key, _virtual_x);
+                cont_body = this.body.draw(container_height, column_state, view_state, false, x, x0, size_key);
                 first_col = false;
                 if (!preserve_width) {
                     for (const {td, metadata} of cont_body.tds) {

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -50,7 +50,7 @@ export class RegularBodyViewModel extends ViewModel {
         return {td, metadata};
     }
 
-    draw(container_height, column_state, view_state, th = false, x, x0, size_key, _virtual_x) {
+    draw(container_height, column_state, view_state, th = false, x, x0, size_key) {
         const {cidx, column_data, row_headers} = column_state;
         let {row_height} = view_state;
         let metadata;
@@ -75,11 +75,11 @@ export class RegularBodyViewModel extends ViewModel {
                     if (prev_col && (prev_col_metadata.value === row_header || row_header === undefined) && !prev_col.hasAttribute("rowspan")) {
                         cidx_offset[ridx] = cidx_offset[ridx] ? cidx_offset[ridx] + 1 : 2;
                         prev_col.setAttribute("colspan", cidx_offset[ridx]);
-                        this._replace_cell(undefined, ridx, cidx + i);
+                        this._replace_cell(ridx, cidx + i);
                     } else if (prev_row && prev_row_metadata.value === row_header && !prev_row.hasAttribute("colspan")) {
                         ridx_offset[i] = ridx_offset[i] ? ridx_offset[i] + 1 : 2;
                         prev_row.setAttribute("rowspan", ridx_offset[i]);
-                        this._replace_cell(undefined, ridx, cidx + i);
+                        this._replace_cell(ridx, cidx + i);
                     } else {
                         obj = this._draw_td("TH", ridx, row_header, cidx + i, column_state, view_state, i);
                         obj.td.style.display = "";
@@ -106,7 +106,7 @@ export class RegularBodyViewModel extends ViewModel {
                     obj.metadata.y1 = view_state.y1;
                     obj.metadata.dx = x - x0;
                     obj.metadata.dy = obj.metadata.y - obj.metadata.y0;
-                    obj.metadata._virtual_x = _virtual_x;
+                    obj.metadata._virtual_x = cidx;
                     tds[0] = obj;
                 }
 

--- a/src/js/view_model.js
+++ b/src/js/view_model.js
@@ -49,7 +49,7 @@ export class ViewModel {
         }
     }
 
-    _replace_cell(new_td, ridx, cidx) {
+    _replace_cell(ridx, cidx) {
         const {tr, row_container} = this._get_row(ridx);
         let td = row_container[cidx];
         if (td) {


### PR DESCRIPTION
Fixes buggy column-resize behavior when the actual header edge which was clicked on belongs to a column group.  Before:

![resize_old](https://user-images.githubusercontent.com/60666/114786738-a5d1d680-9d4c-11eb-9d5a-225a5796c1ae.gif)
 
After:

![resize_new](https://user-images.githubusercontent.com/60666/114786776-b6824c80-9d4c-11eb-95c0-fc6186766f80.gif)
