### PR TITLE
update paths from examples to features

### DIFF
--- a/features/area_clipboard.md
+++ b/features/area_clipboard.md
@@ -16,7 +16,7 @@ Now we'll need to make the area selection behavior available by including the
 `area_mouse_selection` example ...
 
 ```html
-<script src="/dist/examples/area_mouse_selection.js"></script>
+<script src="/dist/features/area_mouse_selection.js"></script>
 ```
 
 and we'll also need a quick helper `function` to `getSelectedAreas()`.

--- a/features/row_column_area_selection.md
+++ b/features/row_column_area_selection.md
@@ -93,9 +93,9 @@ here. We'll need to set our `table`'s `DataListener` and make the initial
 
 ```html
 <script type="module">
-    import { addRowMouseSelection } from "/dist/examples/row_mouse_selection.js";
-    import { addColumnMouseSelection } from "/dist/examples/column_mouse_selection.js";
-    import { addAreaMouseSelection } from "/dist/examples/area_mouse_selection.js";
+    import { addRowMouseSelection } from "/dist/features/row_mouse_selection.js";
+    import { addColumnMouseSelection } from "/dist/features/column_mouse_selection.js";
+    import { addAreaMouseSelection } from "/dist/features/area_mouse_selection.js";
     import { dataListener } from "/dist/examples/two_billion_rows.js";
 
     window.addEventListener("load", () => {


### PR DESCRIPTION
I was working through https://github.com/jpmorganchase/regular-table/blob/master/features/row_column_area_selection.md#adding-the-behaviors for https://github.com/jpmorganchase/ipyregulartable/issues/47 and noticed what seemed to be a few paths reference js files in `examples` that seem to be listed in `features` instead