### PR TITLE
Metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,28 @@ repeated elements in a sequence will be automatically merged via `rowspan` and
 `colspan` attributes.  In this example, e.g. `"Rowgroup 1"` will only output
 to one `<th>` node in the resulting `<table>`.
 
+### `metadata` Data-Aware Styling
+
+A `dataListener` may also optionally provide a `metadata` field in its response,
+a two dimensional `Array` of the same dimensions as `data`.  The values in this
+field will accompany the metadata records returned by `regular-table`'s
+`getMeta()` method (as described in the next section). 
+
+```json
+{
+    "num_rows": 26,
+    "num_columns": 3,
+    "data": [
+        [-1, 1],
+        ["A", "B"]
+    ],
+    "metadata": [
+        ["pos", "neg"],
+        ["green", "red"]
+    ],
+}
+```
+
 ### `async` Data Models
 
 With an `async` data model, it's easy to serve `getDataSlice()` remotely

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -355,18 +355,19 @@ export class RegularVirtualTableViewModel extends HTMLElement {
                 })
             );
 
-            let last_cells;
+            let last_cells = [];
             for await (last_cells of this.table_model.draw(this._container_size, this._view_cache, this._selected_id, preserve_width, viewport, num_columns)) {
                 this._is_styling = true;
                 const callbacks = this._style_callbacks;
                 for (const callback of callbacks) {
                     await callback({detail: this});
                 }
-                this._is_styling = false;
 
-                if (!this._invalidated) {
+                this._is_styling = false;
+                if (!this._invalidated && last_cells !== undefined) {
                     break;
                 }
+
                 this._invalidated = false;
             }
 

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -79,7 +79,7 @@ export class RegularTableViewModel {
     async *draw(container_size, view_cache, selected_id, preserve_width, viewport, num_columns) {
         const {width: container_width, height: container_height} = container_size;
         const {view, config} = view_cache;
-        let {data, row_headers, column_headers} = await view(viewport.start_col, viewport.start_row, viewport.end_col, viewport.end_row);
+        let {data, row_headers, column_headers, metadata: data_listener_metadata} = await view(viewport.start_col, viewport.start_row, viewport.end_col, viewport.end_row);
         const {start_row: ridx_offset = 0, start_col: x0 = 0, end_col: x1 = 0, end_row: y1 = 0} = viewport;
 
         // pad row_headers for embedded renderer
@@ -153,12 +153,15 @@ export class RegularTableViewModel {
                         column_headers[dcidx] = new_col.column_headers?.[0];
                     }
                 }
+
                 const column_name = column_headers?.[dcidx] || "";
                 const column_data = data[dcidx];
+                const column_data_listener_metadata = data_listener_metadata?.[dcidx];
                 const column_state = {
                     column_name,
                     cidx: _virtual_x,
                     column_data,
+                    column_data_listener_metadata,
                     row_headers,
                     first_col,
                 };

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -54,7 +54,7 @@ export class RegularTableViewModel {
      */
     autosize_cells(last_cells) {
         while (last_cells.length > 0) {
-            const [cell, metadata] = last_cells.pop();
+            const [cell, metadata, row_height_cell] = last_cells.pop();
             let offsetWidth;
             const style = getComputedStyle(cell);
             if (style.boxSizing !== "border-box") {
@@ -64,7 +64,7 @@ export class RegularTableViewModel {
             } else {
                 offsetWidth = cell.offsetWidth;
             }
-            this._column_sizes.row_height = this._column_sizes.row_height || cell.offsetHeight;
+            this._column_sizes.row_height = this._column_sizes.row_height || row_height_cell.offsetHeight;
             this._column_sizes.indices[metadata.size_key] = offsetWidth;
             const is_override = this._column_sizes.override.hasOwnProperty(metadata.size_key);
             if (offsetWidth && !is_override) {
@@ -134,7 +134,7 @@ export class RegularTableViewModel {
                 for (let i = 0; i < view_cache.config.row_pivots.length; i++) {
                     const {td, metadata} = cont_body.tds[i] || {};
                     const {th, metadata: hmetadata} = cont_heads[i];
-                    last_cells.push([th || td, hmetadata || metadata]);
+                    last_cells.push([th || td, hmetadata || metadata, td || th]);
                 }
             }
         }
@@ -170,7 +170,7 @@ export class RegularTableViewModel {
                 first_col = false;
                 if (!preserve_width) {
                     for (const {td, metadata} of cont_body.tds) {
-                        last_cells.push([cont_head.th || td, cont_head.metadata || metadata]);
+                        last_cells.push([cont_head.th || td, cont_head.metadata || metadata, td || cont_head.th]);
                     }
                 }
 
@@ -178,7 +178,7 @@ export class RegularTableViewModel {
                 if (last_measured_col_width) {
                     view_state.viewport_width += last_measured_col_width;
                 } else {
-                    view_state.viewport_width += cont_body.tds.reduce((x, y) => x + y.td?.offsetWidth, 0) || cont_head.th.offsetWidth;
+                    view_state.viewport_width += cont_head.th.offsetWidth;
                 }
 
                 view_state.row_height = view_state.row_height || cont_body.row_height;

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -222,7 +222,7 @@ export class RegularTableViewModel {
                 if (last_measured_col_width) {
                     view_state.viewport_width += last_measured_col_width;
                 } else {
-                    view_state.viewport_width += cont_head.th.offsetWidth;
+                    view_state.viewport_width += cont_head.th?.offsetWidth || cont_body.tds.reduce((x, y) => x + y.td?.offsetWidth, 0);
                 }
 
                 view_state.row_height = view_state.row_height || cont_body.row_height;

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -51,7 +51,7 @@ export class RegularBodyViewModel extends ViewModel {
     }
 
     draw(container_height, column_state, view_state, th = false, x, x0, size_key) {
-        const {cidx, column_data, row_headers} = column_state;
+        const {cidx, column_data, row_headers, column_data_listener_metadata} = column_state;
         let {row_height} = view_state;
         let metadata;
         const ridx_offset = [],
@@ -95,13 +95,16 @@ export class RegularBodyViewModel extends ViewModel {
                         cidx_offset[ridx] = 1;
                         tds[i] = obj;
                     }
-                    ridx++;
                 } else {
-                    obj = this._draw_td("TD", ridx++, val, cidx, column_state, view_state, size_key);
+                    obj = this._draw_td("TD", ridx, val, cidx, column_state, view_state, size_key);
+                    if (column_data_listener_metadata) {
+                        obj.metadata.user = column_data_listener_metadata[ridx];
+                    }
+
                     obj.metadata.x = x;
                     obj.metadata.x0 = x0;
                     obj.metadata.x1 = view_state.x1;
-                    obj.metadata.row_header = id || {test: 2};
+                    obj.metadata.row_header = id || [];
                     obj.metadata.y0 = view_state.ridx_offset;
                     obj.metadata.y1 = view_state.y1;
                     obj.metadata.dx = x - x0;
@@ -110,6 +113,7 @@ export class RegularBodyViewModel extends ViewModel {
                     tds[0] = obj;
                 }
 
+                ridx++;
                 metadata = obj ? obj.metadata : metadata;
                 row_height = row_height || obj?.td.offsetHeight;
                 if (ridx * row_height > container_height) {


### PR DESCRIPTION
* Adds a new key `metadata` to the Data Listener Response API, which uses an identically dimensioned `Array` to pass non-rendered metadata to Style Listeners.  This key may be used to e.g. supply color, font or opacity information to a Style Listener from the data model, without rendering this information into the DOM first.

* Shfit+dblclick on a column header now resets _all_ column widths to their auto-size defaults.

* A few rendering fixes as well, which minimize the number of page relayout events are triggered from (1) sudden resize events (e.g. panel collapse), and (2) column resizing.