### PR TITLE
Preserve classname

### DIFF
--- a/src/js/table.js
+++ b/src/js/table.js
@@ -157,16 +157,16 @@ export class RegularTableViewModel {
                     // been seen by the renderer.
                     let end_col_offset = 0,
                         size_extension = 0;
-                    while (this._column_sizes.indices.length > _virtual_x + x0 + end_col_offset && size_extension + view_state.viewport_width < container_width) {
+                    while (this._column_sizes.indices.length > _virtual_x + x0 + end_col_offset + 1 && size_extension + view_state.viewport_width < container_width) {
                         end_col_offset++;
                         size_extension += this._column_sizes.indices[_virtual_x + x0 + end_col_offset];
                     }
 
                     if (size_extension + view_state.viewport_width < container_width) {
-                        const estimate = Math.ceil(((dcidx + end_col_offset) * container_width) / (view_state.viewport_width + size_extension) - missing_cidx + 1);
-                        viewport.end_col = Math.max(1, Math.min(num_visible_columns - 1, missing_cidx + estimate));
+                        const estimate = Math.min(num_columns, missing_cidx + 5); //Math.ceil(((dcidx + end_col_offset) * container_width) / (view_state.viewport_width + size_extension) + 1);
+                        viewport.end_col = Math.max(1, Math.min(num_columns, estimate));
                     } else {
-                        viewport.end_col = Math.max(1, Math.min(num_visible_columns - 1, missing_cidx + end_col_offset));
+                        viewport.end_col = Math.max(1, Math.min(num_columns, missing_cidx + end_col_offset));
                     }
 
                     // Fetch the new data window extension and append it to the

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -21,7 +21,6 @@ export class RegularHeaderViewModel extends ViewModel {
     _draw_group_th(offset_cache, d, column) {
         const th = this._get_cell("TH", d, offset_cache[d] || 0);
         offset_cache[d] += 1;
-        th.className = "";
         th.removeAttribute("colspan");
         th.style.minWidth = "0";
 
@@ -46,7 +45,6 @@ export class RegularHeaderViewModel extends ViewModel {
         metadata.column_header = column;
         metadata.value = column_name;
         metadata.value = column_name;
-        th.className = "";
         return metadata;
     }
 


### PR DESCRIPTION
Previously, while subsequent calls to `draw()` would re-use pre-existing DOM elements such as `<th>` when appropriate, they would pro-actively clear `className` before applying the default classes and calling style handlers.  This PR removes this behavior, which suppresses some re-renders at the expense of requiring `styleListener()` implementations to both `set` _and_ _`reset`_ any classes they wish to modify (where currently they only need implement `set`, since `draw()` would clear the `className` itself).  `regular-table`'s examples all already had this behavior, but this is nonetheless a breaking change.

The old behavior may be trivially implement in a `styleListener` by resetting `className`:

```javascript
table.addStyleListener(() => {
    for (const td of table.querySelectorAll("td, th"}) {
        td.className = "";
        // ...
    }
});
```

