### PR TITLE
Update typings for 0.4.0; add 99% automated typescript declarations build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,8 +189,9 @@ ENV/
 .DS_Store
 
 .autoversion
-docs/api
+declarations/
+docs/api/
 docs/index.md
-.jupyter
+.jupyter/
 python_junit.xml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Development
+
+## Development install
+
+First install `dev_dependencies`:
+
+```bash
+yarn
+```
+
+Build the library
+
+```bash
+yarn build
+```
+
+Run the test suite
+
+```bash
+yarn test
+```
+
+Start the example server at [`http://localhost:8080/examples/`](http://localhost:8080/examples/)
+
+```bash
+yarn start
+```
+
+## How to rebuild the Typescript declarations
+
+### Step-by-step
+
+1. For the duration of building declarations, temporarily `export` the
+`RegularTableElement` in `src/js/index.js`:
+
+```javascript
+// TEMP: export keyword added for building declarations
+export class RegularTableElement extends RegularViewEventModel {
+```
+
+2. Run typescript declarations build:
+
+```bash
+yarn declarations
+```
+
+This will create `declarations/index.d.ts` and other typescript
+
+3. In `index.d.ts`, replace all lines inbetween the paste guard lines:
+
+```javascript
+  // START: declarations/index.d.ts
+
+  ...
+
+  // END: declarations/index.d.ts
+```
+
+with the contents of the just-built `declarations/index.d.ts`.
+
+### Troubleshooting
+
+If an update to index.d.ts is found to break the compilation of any downstream projects, a likely place to check for errors are the pure jsdoc typedefs in `src/js/index.js` below the RegularTableElement class defintion. Ensure that all of the described types are in sync with their current javascript counterparts.

--- a/declarationsconfig.json
+++ b/declarationsconfig.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+      "allowJs": true,
+      "checkJs": false,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "experimentalDecorators": true,
+      "module": "esnext",
+      "moduleResolution": "node",
+      "target": "esnext",
+
+      "outDir": "declarations",
+      "rootDir": "src/js"
+    },
+    "include": ["src/js/index.js"]
+  }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ declare module 'regular-table' {
     // only need the @types/react pkg for this, not the runtime react pkg
     import { DetailedHTMLProps, HTMLAttributes } from "react";
 
+    export const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"] as const;
+
     /**
      * The `<regular-table>` custom element.
      *
@@ -141,7 +143,7 @@ declare module 'regular-table' {
          *     };
          * })
          */
-        setDataListener(dataListener: DataListener): void;
+        setDataListener(dataListener: DataListener, options?: {virtual_mode: (typeof VIRTUAL_MODES)[number]}): void;
     }
 
     /**
@@ -264,16 +266,16 @@ declare module 'regular-table' {
          * - The `Array` for this `y` in
          * `DataResponse.row_headers`, if it was provided.
          */
-        row_header?: Array<object>;
+        row_header?: (string | HTMLElement)[];
         /**
          * - The `Array` for this `x` in
          * `DataResponse.column_headers`, if it was provided.
          */
-        column_header?: Array<object>;
+        column_header?: (string | HTMLElement)[];
         /**
          * - The value dispalyed in the cell or header.
          */
-        value?: object;
+        value?: string | HTMLElement;
     };
 
     /**
@@ -308,21 +310,21 @@ declare module 'regular-table' {
          * `Array` of column group headers, in specificity order.  No `<thead>`
          * will be generated if this property is not provided.
          */
-        column_headers?: Array<Array<object>>;
+        column_headers?: MetaData["value"][][];
         /**
          * - A two dimensional
          * `Array` of row group headers, in specificity order.  No `<th>`
          * elements within `<tbody>` will be generated if this property is not
          * provided.
          */
-        row_headers?: Array<Array<object>>;
+        row_headers?: MetaData["value"][][];
         /**
          * - A two dimensional `Array`
          * representing a rectangular section of the underlying data set from
          * (x0, y0) to (x1, y1), arranged in columnar fashion such that
          * `data[x][y]` returns the `y`th row of the `x`th column of the slice.
          */
-        data: Array<Array<object>>;
+        data: MetaData["value"][][];
         /**
          * - Total number of rows in the underlying
          * data set.

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,12 +84,7 @@ declare module 'regular-table' {
          * optionally async callback, you can select <td>, <th>, etc. elements
          * via regular DOM API methods like querySelectorAll().
          *
-         * @public
-         * @memberof RegularTableElement
-         * @param {function({detail: RegularTableElement}): void} styleListener - A
-         * (possibly async) function that styles the inner <table>.
-         * @returns {function(): void} A function to remove this style listener.
-         * @example
+         * Example:
          * const unsubscribe = table.addStyleListener(() => {
          *     for (const td of table.querySelectorAll("td")) {
          *         td.setAttribute("contenteditable", true);
@@ -99,6 +94,11 @@ declare module 'regular-table' {
          * setTimeout(() => {
          *     unsubscribe();
          * }, 1000);
+         * @public
+         * @memberof RegularTableElement
+         * @param {function({detail: RegularTableElement}): void} styleListener - A
+         * (possibly async) function that styles the inner <table>.
+         * @returns {function(): void} A function to remove this style listener.
          */
         public addStyleListener(styleListener: (arg0: {
             detail: RegularTableElement;
@@ -121,18 +121,18 @@ declare module 'regular-table' {
          * your `StyleListener` is invoked, use this method to look up additional
          * `MetaData` about any `HTMLTableCellElement` in the rendered `<table>`.
          *
+         * Example:
+         * const elems = document.querySelector("td:last-child td:last_child");
+         * const metadata = table.getMeta(elems);
+         * console.log(`Viewport corner is ${metadata.x}, ${metadata.y}`);
+         *
+         * const header = table.getMeta({row_header_x: 1, y: 3}).row_header;
          * @public
          * @memberof RegularTableElement
          * @param {HTMLTableCellElement|Partial<MetaData>} element - The child element
          * of this `<regular-table>` for which to look up metadata, or a
          * coordinates-like object to refer to metadata by logical position.
          * @returns {MetaData} The metadata associated with the element.
-         * @example
-         * const elems = document.querySelector("td:last-child td:last_child");
-         * const metadata = table.getMeta(elems);
-         * console.log(`Viewport corner is ${metadata.x}, ${metadata.y}`);
-         * @example
-         * const header = table.getMeta({row_header_x: 1, y: 3}).row_header;
          */
         public getMeta(element: HTMLTableCellElement | Partial<MetaData>): MetaData;
         /**
@@ -140,16 +140,16 @@ declare module 'regular-table' {
          * method resets the internal state, which makes it convenient to measure
          * performance at regular intervals (see example).
          *
-         * @public
-         * @memberof RegularTableElement
-         * @returns {Performance} Performance data aggregated since the last
-         * call to `getDrawFPS()`.
-         * @example
+         * Example:
          * const table = document.getElementById("my_regular_table");
          * setInterval(() => {
          *     const {real_fps} = table.getDrawFPS();
          *     console.log(`Measured ${fps} fps`)
          * });
+         * @public
+         * @memberof RegularTableElement
+         * @returns {Performance} Performance data aggregated since the last
+         * call to `getDrawFPS()`.
          */
         public getDrawFPS(): Performance;
         /**
@@ -158,14 +158,14 @@ declare module 'regular-table' {
          * and `scrollTop` relative to the underlying widths of its columns
          * and heights of its rows.
          *
+         * Example:
+         * table.scrollToCell(1, 3, 10, 30);
          * @public
          * @memberof RegularTableElement
          * @param {number} x - The left most `x` index column to scroll into view.
          * @param {number} y - The top most `y` index row to scroll into view.
          * @param {number} ncols - Total number of columns in the data model.
          * @param {number} nrows - Total number of rows in the data model.
-         * @example
-         * table.scrollToCell(1, 3, 10, 30);
          */
         public scrollToCell(x: number, y: number, ncols: number, nrows: number): Promise<void>;
         /**
@@ -173,6 +173,14 @@ declare module 'regular-table' {
          * which will be called whenever a new data slice is needed to render.
          * Calls to `draw()` will fail if no `DataListener` has been set
          *
+         * Example:
+         * table.setDataListener((x0, y0, x1, y1) => {
+         *     return {
+         *         num_rows: num_rows = DATA[0].length,
+         *         num_columns: DATA.length,
+         *         data: DATA.slice(x0, x1).map(col => col.slice(y0, y1))
+         *     };
+         * })
          * @public
          * @memberof RegularTableElement
          * @param {DataListener} dataListener
@@ -184,14 +192,6 @@ declare module 'regular-table' {
          * The `virtual_mode` options flag may be one of "both", "horizontal",
          * "vertical", or "none" indicating which dimensions of the table should be
          * virtualized (vs. rendering completely).
-         * @example
-         * table.setDataListener((x0, y0, x1, y1) => {
-         *     return {
-         *         num_rows: num_rows = DATA[0].length,
-         *         num_columns: DATA.length,
-         *         data: DATA.slice(x0, x1).map(col => col.slice(y0, y1))
-         *     };
-         * })
          */
         public setDataListener(dataListener: DataListener, { virtual_mode }?: {
             virtual_mode: ("both" | "horizontal" | "vertical" | "none");
@@ -256,6 +256,25 @@ declare module 'regular-table' {
      * `HTMLTableCellElement`, use this object to map rendered `<th>` or `<td>`
      * elements back to your `data`, `row_headers` or `column_headers` within
      * listener functions for `addStyleListener()` and `addEventListener()`.
+     *
+     * Example:
+     *
+     * MetaData                     (x = 0, column_header_y = 0))
+     *                              *-------------------------------------+
+     *                              |                                     |
+     *                              |                                     |
+     *                              +-------------------------------------+
+     * (row_header_x = 0, y = 0)    (x = 0, y = 0)
+     * *------------------------+   *-------------------------------------+
+     * |                        |   |                                     |
+     * |                        |   |      (x0, y0)                       |
+     * |                        |   |      *---------------*              |
+     * |                        |   |      |               |              |
+     * |                        |   |      |     * (x, y)  |              |
+     * |                        |   |      |               |              |
+     * |                        |   |      *---------------* (x1, y1)     |
+     * |                        |   |                                     |
+     * +------------------------+   +-------------------------------------+
      */
     export type MetaData = {
         /**
@@ -341,6 +360,24 @@ declare module 'regular-table' {
      * different regions to achieve a compelte render as it must estimate
      * certain dimensions.  You must construct a `DataResponse` object to
      * implement a `DataListener`.
+     *
+     * Example:
+     * {
+     *     "num_rows": 26,
+     *     "num_columns": 3,
+     *     "data": [
+     *         [0, 1],
+     *         ["A", "B"]
+     *     ],
+     *     "row_headers": [
+     *         ["Rowgroup 1", "Row 1"],
+     *         ["Rowgroup 1", "Row 2"]
+     *     ],
+     *     "column_headers": [
+     *         ["Colgroup 1", "Column 1"],
+     *         ["Colgroup 1", "Column 2"]
+     *     ]
+     * }
      */
     export type DataResponse = {
         /**
@@ -404,7 +441,7 @@ declare module 'regular-table' {
         num_columns: () => number;
     };
     /**
-     * Public summary of header and body base type.
+     * Public summary of table_model.header and table_model.body base type.
      */
     export type ViewModel = {
         table: any;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "build:rollup": "rollup -c rollup.config.js",
         "build": "npm-run-all -p build:*",
         "clean": "rimraf dist",
+        "declarations": "tsc -b declarationsconfig.json",
         "docs": "jsdoc2md src/js/index.js --separators > api.md",
         "fix": "eslint --fix src features/*.md examples/*.md examples/*.html && prettier --write features/*.md",
         "lint": "npm-run-all lint:*",
@@ -84,6 +85,7 @@
         "rollup-plugin-terser": "^6.1.0",
         "source-map-explorer": "^2.4.2",
         "source-map-loader": "^0.2.4",
-        "superstore-arrow": "^1.0.0"
+        "superstore-arrow": "^1.0.0",
+        "typescript": "^4.2.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@babel/preset-env": "^7.9.0",
         "@finos/perspective": "=0.5.0",
         "@rollup/plugin-babel": "^5.0.2",
-        "@types/react": "^16.9.38",
+        "@types/react": "^17.0.0",
         "babel-eslint": "^10.1.0",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-transform-custom-element-classes": "^0.1.0",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,18 +9,21 @@
  */
 
 import {METADATA_MAP} from "./constants";
-import {RegularTableViewModel} from "./table";
 import {RegularViewEventModel} from "./events";
+import {RegularTableViewModel} from "./table";
 import {get_draw_fps} from "./utils";
 
-/**
- * The `virtual_mode` options flag may be one of "both", "horizontal",
- * "vertical", or "none" indicating which dimensions of the table should be
- * virtualized (vs. rendering completely).
- *
- * @private
- */
 const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"];
+
+// /**
+//  * @public
+//  * @typedef {table: any, cells: any[], rows: any[], num_columns: () => number, num_rows: () => number} ViewModel
+//  */
+
+// /**
+//  * @public
+//  * @typedef {header: ViewModel, body: ViewModel, num_columns: () => number} TableModel
+//  */
 
 /**
  * The `<regular-table>` custom element.
@@ -52,10 +55,15 @@ class RegularTableElement extends RegularViewEventModel {
             this.create_shadow_dom();
             this.register_listeners();
             this.setAttribute("tabindex", "0");
+
+            /** @private */
             this._column_sizes = {auto: {}, override: {}, indices: []};
-            this._style_callbacks = [];
-            this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this);
+            /** @private */
             this._initialized = true;
+            /** @private */
+            this._style_callbacks = [];
+            /** @public @type {TableModel} */
+            this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this);
         }
     }
 
@@ -67,9 +75,13 @@ class RegularTableElement extends RegularViewEventModel {
      * @memberof RegularTableElement
      */
     _reset_viewport() {
+        /** @private @type {number} */
         this._start_row = undefined;
+        /** @private @type {number} */
         this._end_row = undefined;
+        /** @private @type {number} */
         this._start_col = undefined;
+        /** @private @type {number} */
         this._end_col = undefined;
     }
 
@@ -92,7 +104,7 @@ class RegularTableElement extends RegularViewEventModel {
      * on the next draw() call.
      *
      * @internal
-     * @private
+     * @protected
      * @memberof RegularTableElement
      */
     _resetAutoSize() {
@@ -164,11 +176,15 @@ class RegularTableElement extends RegularViewEventModel {
      * dimensions and attempt to draw more columns.  Useful if your
      * `StyleListener` changes a cells dimensions, otherwise `<regular-table>`
      * may not draw enough columns to fill the screen.
+     *
+     * @public
+     * @memberof RegularTableElement
      */
     invalidate() {
         if (!this._is_styling) {
             throw new Error("Cannot call `invalidate()` outside of a `StyleListener`");
         }
+        /** @private */
         this._invalidated = true;
     }
 
@@ -285,10 +301,37 @@ class RegularTableElement extends RegularViewEventModel {
         };
 
         console.assert(VIRTUAL_MODES.indexOf(virtual_mode) > -1, `Unknown virtual_mode ${virtual_mode};  valid options are "both" (default), "horizontal", "vertical" or "none"`);
+        /** @private */
         this._virtual_mode = virtual_mode;
+        /** @private */
         this._invalid_schema = true;
+        /** @private */
         this._view_cache = {view: dataListener, config, schema};
         this._setup_virtual_scroll();
+    }
+
+    /**
+     * This func only exists to provide hints to doc compulation tools.
+     * Should never be run, and even if it is the body of the func will
+     * never execute.
+     *
+     * @internal
+     * @private
+     * @memberof RegularTableElement
+     */
+    __noop_jsdoc_hints() {
+        if (false) {
+            /**
+             * Draws this virtual panel, given an object of render options that allow
+             * the implementor to fine tune the individual render frames based on the
+             * interaction and previous render state.
+             *
+             * @public
+             * @type {(opt?: DrawOptions) => void}
+             * @memberof RegularTableElement
+             * */
+            this.draw = null;
+        }
     }
 }
 
@@ -434,4 +477,45 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * @returns {Promise<DataResponse>} The resulting `DataResponse`.  Make sure
  * to `resolve` or `reject` the `Promise`, or your `<regular-table>` will
  * never render!
+ */
+
+/**
+ * Options for the draw method. `reset_scroll_position` will not prevent
+ * the viewport from moving as `draw()` may change the dimensions of the
+ * virtual_panel (and thus, absolute scroll offset).  This calls
+ * `reset_scroll`, which will trigger `_on_scroll` and ultimately `draw()`
+ * again;  however, this call to `draw()` will be for the same viewport
+ * and will not actually cause a render.
+ *
+ * @public
+ * @typedef DrawOptions
+ * @type {object}
+ * @property {boolean} [invalid_viewport]
+ * @property {boolean} [preserve_width]
+ * @property {boolean} [reset_scroll_position]
+ * @property {boolean} [swap]
+ */
+
+/**
+ * Public summary of table_model type.
+ *
+ * @public
+ * @typedef TableModel
+ * @type {object}
+ * @property {ViewModel} header
+ * @property {ViewModel} body
+ * @property {() => number} num_columns
+ */
+
+/**
+ * Public summary of header and body base type.
+ *
+ * @public
+ * @typedef ViewModel
+ * @type {object}
+ * @property {any} table
+ * @property {any[]} cells
+ * @property {any[]} rows
+ * @property {() => number} num_columns
+ * @property {() => number} num_rows
  */

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -13,6 +13,13 @@ import {RegularTableViewModel} from "./table";
 import {RegularViewEventModel} from "./events";
 import {get_draw_fps} from "./utils";
 
+/**
+ * The `virtual_mode` options flag may be one of "both", "horizontal",
+ * "vertical", or "none" indicating which dimensions of the table should be
+ * virtualized (vs. rendering completely).
+ *
+ * @private
+ */
 const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"];
 
 /**
@@ -256,7 +263,8 @@ class RegularTableElement extends RegularViewEventModel {
      * `dataListener` is called by to request a rectangular section of data
      * for a virtual viewport, (x0, y0, x1, y1), and returns a `DataReponse`
      * object.
-     * @param {Options} options.virtual_mode
+     * @param {Object} options
+     * @param {("both"|"horizontal"|"vertical"|"none")} options.virtual_mode
      * The `virtual_mode` options flag may be one of "both", "horizontal",
      * "vertical", or "none" indicating which dimensions of the table should be
      * virtualized (vs. rendering completely).
@@ -293,6 +301,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * `draw()` from some time interval (captured in milliseconds by the
  * `elapsed` proprty).
  *
+ * @public
  * @typedef Performance
  * @type {object}
  * @property {number} avg - Avergage milliseconds per call.
@@ -327,6 +336,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * |                        |   |                                     |
  * +------------------------+   +-------------------------------------+
  *
+ * @public
  * @typedef MetaData
  * @type {object}
  * @property {number} [x] - The `x` index in your virtual data model.
@@ -357,11 +367,11 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * from `row_headers`.
  * @property {number} size_key - The unique index of this column in a full
  * `<table>`, which is `x` + (Total Row Header Columns).
- * @property {Array<object>} [row_header] - The `Array` for this `y` in
+ * @property {(string|HTMLElement)[]} [row_header] - The `Array` for this `y` in
  * `DataResponse.row_headers`, if it was provided.
- * @property {Array<object>} [column_header] - The `Array` for this `x` in
+ * @property {(string|HTMLElement)[]} [column_header] - The `Array` for this `x` in
  * `DataResponse.column_headers`, if it was provided.
- * @property {object} [value] - The value dispalyed in the cell or header.
+ * @property {(string|HTMLElement)} [value] - The value dispalyed in the cell or header.
  */
 
 /**
@@ -372,16 +382,17 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * certain dimensions.  You must construct a `DataResponse` object to
  * implement a `DataListener`.
  *
+ * @public
  * @typedef DataResponse
  * @type {object}
- * @property {Array<Array<object>>} [column_headers] - A two dimensional
+ * @property {(string|HTMLElement)[][]} [column_headers] - A two dimensional
  * `Array` of column group headers, in specificity order.  No `<thead>`
  * will be generated if this property is not provided.
- * @property {Array<Array<object>>} [row_headers] - A two dimensional
+ * @property {(string|HTMLElement)[][]} [row_headers] - A two dimensional
  * `Array` of row group headers, in specificity order.  No `<th>`
  * elements within `<tbody>` will be generated if this property is not
  * provided.
- * @property {Array<Array<object>>} data - A two dimensional `Array`
+ * @property {(string|HTMLElement)[][]} data - A two dimensional `Array`
  * representing a rectangular section of the underlying data set from
  * (x0, y0) to (x1, y1), arranged in columnar fashion such that
  * `data[x][y]` returns the `y`th row of the `x`th column of the slice.
@@ -414,6 +425,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * `Event`); and returns a `Promise` for a `DataResponse` object for this
  * region (as opposed to returning `void` as a standard event listener).
  *
+ * @public
  * @callback DataListener
  * @param {number} x0 - The origin `x` index (column).
  * @param {number} y0 - The origin `y` index (row).

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -15,16 +15,6 @@ import {get_draw_fps} from "./utils";
 
 const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"];
 
-// /**
-//  * @public
-//  * @typedef {table: any, cells: any[], rows: any[], num_columns: () => number, num_rows: () => number} ViewModel
-//  */
-
-// /**
-//  * @public
-//  * @typedef {header: ViewModel, body: ViewModel, num_columns: () => number} TableModel
-//  */
-
 /**
  * The `<regular-table>` custom element.
  *
@@ -136,12 +126,7 @@ class RegularTableElement extends RegularViewEventModel {
      * optionally async callback, you can select <td>, <th>, etc. elements
      * via regular DOM API methods like querySelectorAll().
      *
-     * @public
-     * @memberof RegularTableElement
-     * @param {function({detail: RegularTableElement}): void} styleListener - A
-     * (possibly async) function that styles the inner <table>.
-     * @returns {function(): void} A function to remove this style listener.
-     * @example
+     * Example:
      * const unsubscribe = table.addStyleListener(() => {
      *     for (const td of table.querySelectorAll("td")) {
      *         td.setAttribute("contenteditable", true);
@@ -151,6 +136,11 @@ class RegularTableElement extends RegularViewEventModel {
      * setTimeout(() => {
      *     unsubscribe();
      * }, 1000);
+     * @public
+     * @memberof RegularTableElement
+     * @param {function({detail: RegularTableElement}): void} styleListener - A
+     * (possibly async) function that styles the inner <table>.
+     * @returns {function(): void} A function to remove this style listener.
      */
     addStyleListener(styleListener) {
         this._style_callbacks = this._style_callbacks.concat(styleListener);
@@ -193,18 +183,18 @@ class RegularTableElement extends RegularViewEventModel {
      * your `StyleListener` is invoked, use this method to look up additional
      * `MetaData` about any `HTMLTableCellElement` in the rendered `<table>`.
      *
+     * Example:
+     * const elems = document.querySelector("td:last-child td:last_child");
+     * const metadata = table.getMeta(elems);
+     * console.log(`Viewport corner is ${metadata.x}, ${metadata.y}`);
+     *
+     * const header = table.getMeta({row_header_x: 1, y: 3}).row_header;
      * @public
      * @memberof RegularTableElement
      * @param {HTMLTableCellElement|Partial<MetaData>} element - The child element
      * of this `<regular-table>` for which to look up metadata, or a
      * coordinates-like object to refer to metadata by logical position.
      * @returns {MetaData} The metadata associated with the element.
-     * @example
-     * const elems = document.querySelector("td:last-child td:last_child");
-     * const metadata = table.getMeta(elems);
-     * console.log(`Viewport corner is ${metadata.x}, ${metadata.y}`);
-     * @example
-     * const header = table.getMeta({row_header_x: 1, y: 3}).row_header;
      */
     getMeta(element) {
         if (typeof element === "undefined") {
@@ -231,16 +221,16 @@ class RegularTableElement extends RegularViewEventModel {
      * method resets the internal state, which makes it convenient to measure
      * performance at regular intervals (see example).
      *
-     * @public
-     * @memberof RegularTableElement
-     * @returns {Performance} Performance data aggregated since the last
-     * call to `getDrawFPS()`.
-     * @example
+     * Example:
      * const table = document.getElementById("my_regular_table");
      * setInterval(() => {
      *     const {real_fps} = table.getDrawFPS();
      *     console.log(`Measured ${fps} fps`)
      * });
+     * @public
+     * @memberof RegularTableElement
+     * @returns {Performance} Performance data aggregated since the last
+     * call to `getDrawFPS()`.
      */
     getDrawFPS() {
         return get_draw_fps();
@@ -252,14 +242,14 @@ class RegularTableElement extends RegularViewEventModel {
      * and `scrollTop` relative to the underlying widths of its columns
      * and heights of its rows.
      *
+     * Example:
+     * table.scrollToCell(1, 3, 10, 30);
      * @public
      * @memberof RegularTableElement
      * @param {number} x - The left most `x` index column to scroll into view.
      * @param {number} y - The top most `y` index row to scroll into view.
      * @param {number} ncols - Total number of columns in the data model.
      * @param {number} nrows - Total number of rows in the data model.
-     * @example
-     * table.scrollToCell(1, 3, 10, 30);
      */
     async scrollToCell(x, y, ncols, nrows) {
         const row_height = this._virtual_panel.offsetHeight / nrows;
@@ -273,6 +263,14 @@ class RegularTableElement extends RegularViewEventModel {
      * which will be called whenever a new data slice is needed to render.
      * Calls to `draw()` will fail if no `DataListener` has been set
      *
+     * Example:
+     * table.setDataListener((x0, y0, x1, y1) => {
+     *     return {
+     *         num_rows: num_rows = DATA[0].length,
+     *         num_columns: DATA.length,
+     *         data: DATA.slice(x0, x1).map(col => col.slice(y0, y1))
+     *     };
+     * })
      * @public
      * @memberof RegularTableElement
      * @param {DataListener} dataListener
@@ -284,14 +282,6 @@ class RegularTableElement extends RegularViewEventModel {
      * The `virtual_mode` options flag may be one of "both", "horizontal",
      * "vertical", or "none" indicating which dimensions of the table should be
      * virtualized (vs. rendering completely).
-     * @example
-     * table.setDataListener((x0, y0, x1, y1) => {
-     *     return {
-     *         num_rows: num_rows = DATA[0].length,
-     *         num_columns: DATA.length,
-     *         data: DATA.slice(x0, x1).map(col => col.slice(y0, y1))
-     *     };
-     * })
      */
     setDataListener(dataListener, {virtual_mode = "both"} = {}) {
         let schema = {};
@@ -360,7 +350,8 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * `HTMLTableCellElement`, use this object to map rendered `<th>` or `<td>`
  * elements back to your `data`, `row_headers` or `column_headers` within
  * listener functions for `addStyleListener()` and `addEventListener()`.
- * @example
+ *
+ * Example:
  *
  * MetaData                     (x = 0, column_header_y = 0))
  *                              *-------------------------------------+
@@ -425,6 +416,23 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * certain dimensions.  You must construct a `DataResponse` object to
  * implement a `DataListener`.
  *
+ * Example:
+ * {
+ *     "num_rows": 26,
+ *     "num_columns": 3,
+ *     "data": [
+ *         [0, 1],
+ *         ["A", "B"]
+ *     ],
+ *     "row_headers": [
+ *         ["Rowgroup 1", "Row 1"],
+ *         ["Rowgroup 1", "Row 2"]
+ *     ],
+ *     "column_headers": [
+ *         ["Colgroup 1", "Column 1"],
+ *         ["Colgroup 1", "Column 2"]
+ *     ]
+ * }
  * @public
  * @typedef DataResponse
  * @type {object}
@@ -443,23 +451,6 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  * data set.
  * @property {number} num_columns - Total number of columns in the
  * underlying data set.
- * @example
- * {
- *     "num_rows": 26,
- *     "num_columns": 3,
- *     "data": [
- *         [0, 1],
- *         ["A", "B"]
- *     ],
- *     "row_headers": [
- *         ["Rowgroup 1", "Row 1"],
- *         ["Rowgroup 1", "Row 2"]
- *     ],
- *     "column_headers": [
- *         ["Colgroup 1", "Column 1"],
- *         ["Colgroup 1", "Column 2"]
- *     ]
- * }
  */
 
 /**
@@ -508,7 +499,7 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  */
 
 /**
- * Public summary of header and body base type.
+ * Public summary of table_model.header and table_model.body base type.
  *
  * @public
  * @typedef ViewModel

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -325,7 +325,6 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * @param {boolean} [options.preserve_width=false]
      * @param {boolean} [options.reset_scroll_position=false]
      * @param {boolean} [options.swap=false]
-     * @returns
      */
     @throttlePromise
     async draw(options = {}) {
@@ -388,6 +387,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
 /**
  * Options for the draw method.
  *
+ * @public
  * @typedef DrawOptions
  * @type {object}
  * @property {boolean} [invalid_viewport]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8745,6 +8745,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,13 +1458,19 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react@^16.9.38":
-  version "16.9.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.38.tgz#868405dace93a4095d3e054f4c4a1de7a1ac0680"
-  integrity sha512-pHAeZbjjNRa/hxyNuLrvbxhhnKyKNiLC6I5fRF2Zr/t/S6zS41MiyzH4+c+1I9vVfvuRt1VS2Lodjr4ZWnxrdA==
+"@types/react@^17.0.5":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
+  integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^2.2.0"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2843,10 +2849,10 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
-  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+csstype@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 cwd@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
This PR makes significant fixes to the typings, as well as adding a mostly automated build for (re)generating the contents of the `index.d.ts` typescript declaration file:

- Typing fixes:
  - [x] `MetaData.value`: was `object`, now `string | HTMLElement`
  - [x] various types associated with `MetaData.value` updated to match with new narrower typing:
  - [x] added typing support for passing options to `RegularTableElement.setDataListener`
  - [x] replace usage of jsdoc `@example` tag with plain `Example:`, to ensure that full doc strings get added to `index.d.ts`
- Automated build:
  - [x] added config for declarations-only typescript build to `decularationsconfig.json`
  - [x] added commands for declarations build to `package.json`
  - [x] add clear step-by-step instructions covering the automated declarations build as well as any manual steps still needed