### PR TITLE
Memoize `<span>` elements

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -31,6 +31,16 @@ const VIRTUAL_MODES = ["both", "horizontal", "vertical", "none"];
  * @extends HTMLElement
  */
 class RegularTableElement extends RegularViewEventModel {
+    constructor() {
+        super();
+        /** @private */
+        this._column_sizes = {auto: {}, override: {}, indices: []};
+        /** @private */
+        this._style_callbacks = [];
+        /** @private */
+        this._initialized = false;
+    }
+
     /**
      * For internal use by the Custom Elements API: "Invoked each time the
      * custom element is appended into a document-connected element".
@@ -46,13 +56,7 @@ class RegularTableElement extends RegularViewEventModel {
             this.register_listeners();
             this.setAttribute("tabindex", "0");
 
-            /** @private */
-            this._column_sizes = {auto: {}, override: {}, indices: []};
-            /** @private */
             this._initialized = true;
-            /** @private */
-            this._style_callbacks = [];
-            /** @public @type {TableModel} */
             this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this);
         }
     }

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -62,7 +62,7 @@ export class RegularTableViewModel {
                 offsetWidth -= parseFloat(style.paddingLeft);
                 offsetWidth -= parseFloat(style.paddingRight);
             } else {
-                offsetWidth = cell.offsetWidth;
+                offsetWidth = parseFloat(window.getComputedStyle(cell).width);
             }
             this._column_sizes.row_height = this._column_sizes.row_height || row_height_cell.offsetHeight;
             this._column_sizes.indices[metadata.size_key] = offsetWidth;

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -258,6 +258,8 @@ export class RegularTableViewModel {
         } finally {
             this.body.clean({ridx: cont_body?.ridx || 0, cidx: _virtual_x});
             this.header.clean();
+            this.body._span_factory.reset();
+            this.header._span_factory.reset();
         }
     }
 }

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -28,12 +28,12 @@ export class RegularHeaderViewModel extends ViewModel {
         if (column instanceof HTMLElement) {
             th.appendChild(column);
         } else {
-            const span = document.createElement("span");
+            const span = this._span_factory.get("span");
             span.textContent = column;
             th.appendChild(span);
         }
 
-        const resizeSpan = document.createElement("span");
+        const resizeSpan = this._span_factory.get("span");
         resizeSpan.className = "rt-column-resize";
         th.appendChild(resizeSpan);
 

--- a/src/js/view_model.js
+++ b/src/js/view_model.js
@@ -16,10 +16,33 @@ import {METADATA_MAP} from "./constants";
  *
  */
 
+class ElemFactory {
+    constructor(name) {
+        this._name = name;
+        this._elements = [];
+        this._index = 0;
+    }
+
+    reset() {
+        this._index = 0;
+    }
+
+    get() {
+        if (!this._elements[this._index]) {
+            this._elements[this._index] = document.createElement(this._name);
+        }
+
+        const elem = this._elements[this._index];
+        this._index += 1;
+        return elem;
+    }
+}
+
 export class ViewModel {
     constructor(column_sizes, container, table) {
         this._column_sizes = column_sizes;
         this._container = container;
+        this._span_factory = new ElemFactory("span");
         this.table = table;
         this.cells = [];
         this.rows = [];


### PR DESCRIPTION
* Memoize `<span>` elements (used in column headers).
* During auto size, calculate width via `parseFloat(window.getComputedStyle(elem).width)`, which returns the sub-pixel units necessary to remove a small flicker when column auto-sizing is performed.