### PR TITLE
Fix screen thrash when "position: sticky" container resize is triggered

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    preset: process.platform === "darwin" ? "jest-puppeteer-docker" : "jest-puppeteer",
+    preset: "jest-puppeteer",
     transform: {},
     coverageDirectory: "coverage",
 };

--- a/src/less/container.less
+++ b/src/less/container.less
@@ -33,6 +33,7 @@ div.rt-virtual-panel {
 
 div.rt-scroll-table-clip {
     position: sticky;
+    contain: strict;
     overflow-anchor: none; 
     width: 100%;
     height: 100%;

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -167,7 +167,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["Hello, World!", "", ""]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);


### PR DESCRIPTION
When re-sizing (shrinking) a container containing a `<regular-table>`, the `.rt-table-clip` container with `position: sticky` will sometimes emit a blank frame, causing the table to flicker, only in Chrome.  I've tried a whole laundry list of fixes, including but not limited to:
* Alternatives to `sticky`
    * `fixed` without `position` works but stutters on Safari and overlaps scroll bars on the parent web component.
    * `absolute` with Javascript `position` update stutters on keyboard scroll.
* `-webkit-transform: translate3d(0, 0, 0)`, `transform: translateX(0)`, `backface-visibilitiy: hidden` and various layout-acceleration-forcing CSS properties.
`contains: strict` on the sticky element itself seems to finally do the trick.  This really shouldn't have any affect on `regular-table`, since the DOM is virtual and thus only very slightly overflows the container, but it does.