### PR TITLE
Linear column scrolling

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,9 +14,6 @@ module.exports = {
     ],
     plugins: [
         ["@babel/plugin-proposal-decorators", {legacy: true}],
-        "transform-custom-element-classes",
-        "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining",
         "./scripts/babel-plugin-html-template.js",
     ],
     sourceMaps: true,

--- a/examples/spreadsheet.md
+++ b/examples/spreadsheet.md
@@ -286,20 +286,19 @@ necessary and providing a small buffer to the edge of the visible table.
 ```javascript
 const SCROLL_AHEAD = 4;
 
-function moveSelection(active_cell, dx, dy) {
+async function moveSelection(active_cell, dx, dy) {
     const meta = table.getMeta(active_cell);
-
     if (dx !== 0) {
         if (meta.x + dx < NUM_COLUMNS && 0 <= meta.x + dx) {
             SELECTED_POSITION.x = meta.x + dx;
         }
         if (meta.x1 <= SELECTED_POSITION.x + SCROLL_AHEAD) {
-            table.scrollToCell(meta.x0 + 2, meta.y0, NUM_COLUMNS, NUM_ROWS);
+            await table.scrollToCell(meta.x0 + 2, meta.y0, NUM_COLUMNS, NUM_ROWS);
         } else if (SELECTED_POSITION.x - SCROLL_AHEAD < meta.x0) {
             if (0 < meta.x0 - 1) {
-                table.scrollToCell(meta.x0 - 1, meta.y0, NUM_COLUMNS, NUM_ROWS);
+                await table.scrollToCell(meta.x0 - 1, meta.y0, NUM_COLUMNS, NUM_ROWS);
             } else {
-                table.scrollToCell(0, meta.y0, NUM_COLUMNS, NUM_ROWS);
+                await table.scrollToCell(0, meta.y0, NUM_COLUMNS, NUM_ROWS);
             }
         }
     }
@@ -309,12 +308,12 @@ function moveSelection(active_cell, dx, dy) {
             SELECTED_POSITION.y = meta.y + dy;
         }
         if (meta.y1 <= SELECTED_POSITION.y + SCROLL_AHEAD) {
-            table.scrollToCell(meta.x0, meta.y0 + 1, NUM_COLUMNS, NUM_ROWS);
+            await table.scrollToCell(meta.x0, meta.y0 + 1, NUM_COLUMNS, NUM_ROWS);
         } else if (SELECTED_POSITION.y - SCROLL_AHEAD + 2 < meta.y0) {
             if (0 < meta.y0 - 1) {
-                table.scrollToCell(meta.x0, meta.y0 - 1, NUM_COLUMNS, NUM_ROWS);
+                await table.scrollToCell(meta.x0, meta.y0 - 1, NUM_COLUMNS, NUM_ROWS);
             } else {
-                table.scrollToCell(meta.x0, 0, NUM_COLUMNS, NUM_ROWS);
+                await table.scrollToCell(meta.x0, 0, NUM_COLUMNS, NUM_ROWS);
             }
         }
     }

--- a/features/fixed_column_widths.md
+++ b/features/fixed_column_widths.md
@@ -108,6 +108,21 @@ class DataModel {
         this.columns = this._createColumns();
         this._data = this.columns.map(({ key }) => this._dataset[key]);
         this._columnHeaders = this.columns.map(({ value }) => [value]);
+
+        this.dataListener = (x0, y0, x1, y1) => {
+            const data = this._data
+                .slice(x0, x1)
+                .map((col) => col.slice(y0, y1));
+            const column_headers = this._columnHeaders.slice(x0, x1);
+            const num_columns = this._data.length;
+            const num_rows = this._data[0].length;
+            return {
+                num_rows,
+                num_columns,
+                column_headers,
+                data,
+            };
+        };
     }
 
     _createTextCells(text) {
@@ -135,19 +150,6 @@ class DataModel {
             {}
         );
     }
-
-    dataListener = (x0, y0, x1, y1) => {
-        const data = this._data.slice(x0, x1).map((col) => col.slice(y0, y1));
-        const column_headers = this._columnHeaders.slice(x0, x1);
-        const num_columns = this._data.length;
-        const num_rows = this._data[0].length;
-        return {
-            num_rows,
-            num_columns,
-            column_headers,
-            data,
-        };
-    };
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -419,18 +419,11 @@ declare module 'regular-table' {
      */
     export type DataListener = (x0: number, y0: number, x1: number, y1: number) => Promise<DataResponse>;
     /**
-     * Options for the draw method. `reset_scroll_position` will not prevent
-     * the viewport from moving as `draw()` may change the dimensions of the
-     * virtual_panel (and thus, absolute scroll offset).  This calls
-     * `reset_scroll`, which will trigger `_on_scroll` and ultimately `draw()`
-     * again;  however, this call to `draw()` will be for the same viewport
-     * and will not actually cause a render.
+     * Options for the draw method.
      */
     export type DrawOptions = {
         invalid_viewport?: boolean;
         preserve_width?: boolean;
-        reset_scroll_position?: boolean;
-        swap?: boolean;
     };
     /**
      * Public summary of table_model type.

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -30,8 +30,10 @@ const IOS_DISABLE_OVERSCROLL = false;
  */
 export class RegularViewEventModel extends RegularVirtualTableViewModel {
     register_listeners() {
-        this.addEventListener("mousedown", this._on_click.bind(this));
-        this.addEventListener("dblclick", this._on_dblclick.bind(this));
+        // // TODO see `_on_click_or_dblclick` method jsdoc
+        // this.addEventListener("dblclick", this._on_dblclick.bind(this));
+
+        this.addEventListener("mousedown", this._on_click_or_dblclick.bind(this));
         this.addEventListener("scroll", this._on_scroll.bind(this), {
             passive: true,
         });
@@ -204,6 +206,22 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         if (is_resize) {
             this._on_resize_column(event, element, metadata);
             event.stopImmediatePropagation();
+        }
+    }
+
+    /**
+     * `dblclick` event does not work reliably for some reason so dispatch this
+     * event in JavaScript instead.
+     * @param {`*`} event
+     */
+    async _on_click_or_dblclick(event) {
+        const now = performance.now();
+        if (this._last_clicked_time && now - this._last_clicked_time < 500) {
+            this._last_clicked_time = now;
+            await this._on_dblclick(event);
+        } else {
+            this._last_clicked_time = now;
+            await this._on_click(event);
         }
     }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -34,7 +34,7 @@ class RegularTableElement extends RegularViewEventModel {
     constructor() {
         super();
         /** @private */
-        this._column_sizes = {auto: {}, override: {}, indices: []};
+        this._column_sizes = {auto: [], override: [], indices: []};
         /** @private */
         this._style_callbacks = [];
         /** @private */
@@ -104,8 +104,8 @@ class RegularTableElement extends RegularViewEventModel {
      * @memberof RegularTableElement
      */
     _resetAutoSize() {
-        this._column_sizes.auto = {};
-        this._column_sizes.override = {};
+        this._column_sizes.auto = [];
+        this._column_sizes.override = [];
         this._column_sizes.indices = [];
 
         for (let i = 0; i < this.table_model.header.num_columns(); i++) {
@@ -265,9 +265,13 @@ class RegularTableElement extends RegularViewEventModel {
 
         const row_height = this._virtual_panel.offsetHeight / nrows;
         this.scrollTop = row_height * y + 1;
-        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - this._container_size.width);
-        const percent_left = x / this._max_scroll_column(ncols);
-        this.scrollLeft = Math.ceil(percent_left * total_scroll_width);
+        let scroll_left = 0;
+        while (x > 0) {
+            x--;
+            scroll_left += this._column_sizes.indices[x] || 60;
+        }
+
+        this.scrollLeft = Math.ceil(scroll_left);
         await new Promise(requestAnimationFrame);
         await this.draw.flush();
     }
@@ -486,20 +490,13 @@ if (document.createElement("regular-table").constructor === HTMLElement) {
  */
 
 /**
- * Options for the draw method. `reset_scroll_position` will not prevent
- * the viewport from moving as `draw()` may change the dimensions of the
- * virtual_panel (and thus, absolute scroll offset).  This calls
- * `reset_scroll`, which will trigger `_on_scroll` and ultimately `draw()`
- * again;  however, this call to `draw()` will be for the same viewport
- * and will not actually cause a render.
+ * Options for the draw method.
  *
  * @public
  * @typedef DrawOptions
  * @type {object}
  * @property {boolean} [invalid_viewport]
  * @property {boolean} [preserve_width]
- * @property {boolean} [reset_scroll_position]
- * @property {boolean} [swap]
  */
 
 /**

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -19,7 +19,7 @@ import sub_cell_offsets from "../less/sub-cell-offsets.less";
  * of the underlying <table>. This DOM structure looks a little like
  * this:
  *
- *     +------------------------+      <- div.rt-scroll-container
+ *     +------------------------+      <- regular-table
  *     | +----------------------|------<- div.rt-virtual-panel
  *     | | +------------------+ |      <- div.rt-scroll-table-clip
  *     | | | +----------------|-|--+   <- table             |
@@ -118,12 +118,11 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * @private
      * @memberof RegularVirtualTableViewModel
      * @param {*} nrows
-     * @param {*} reset_scroll_position
      * @returns
      */
-    _calculate_viewport(nrows, num_columns, reset_scroll_position, invalid_columns) {
-        const {start_row, end_row} = this._calculate_row_range(nrows, reset_scroll_position);
-        const {start_col, end_col} = this._calculate_column_range(num_columns, invalid_columns);
+    _calculate_viewport(nrows, num_columns) {
+        const {start_row, end_row} = this._calculate_row_range(nrows);
+        const {start_col, end_col} = this._calculate_column_range(num_columns);
         this._nrows = nrows;
         return {start_col, end_col, start_row, end_row};
     }
@@ -165,10 +164,9 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * @private
      * @memberof RegularVirtualTableViewModel
      * @param {*} nrows
-     * @param {*} reset_scroll_position
      * @returns
      */
-    _calculate_row_range(nrows, reset_scroll_position) {
+    _calculate_row_range(nrows) {
         const {height} = this._container_size;
         const row_height = this._column_sizes.row_height || 19;
         const header_levels = this._view_cache.config.column_pivots.length + 1;
@@ -176,11 +174,27 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         const total_scroll_height = Math.max(1, this._virtual_panel.offsetHeight - this.clientHeight);
         const percent_scroll = Math.max(this.scrollTop, 0) / total_scroll_height;
         const virtual_panel_row_height = height / row_height;
-        const relative_nrows = !reset_scroll_position ? this._nrows || 0 : nrows;
+        const relative_nrows = this._nrows || 0;
         const scroll_rows = Math.max(0, relative_nrows + (header_levels - virtual_panel_row_height));
         let start_row = scroll_rows * percent_scroll;
         let end_row = Math.min(start_row + virtual_panel_row_height, nrows);
         return {start_row, end_row};
+    }
+
+    _calc_start_column() {
+        const scroll_index_offset = this._view_cache.config.row_pivots.length;
+        let start_col = 0;
+        let offset_width = 0;
+        let diff = 0;
+        while (offset_width < this.scrollLeft) {
+            const new_val = this._column_sizes.indices[start_col + scroll_index_offset];
+            diff = this.scrollLeft - offset_width;
+            start_col += 1;
+            offset_width += new_val !== undefined ? new_val : 60;
+        }
+
+        start_col += diff / (this._column_sizes.indices[start_col - 1] || 60);
+        return Math.max(0, start_col - 1);
     }
 
     /**
@@ -193,15 +207,12 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * @memberof RegularVirtualTableViewModel
      * @returns
      */
-    _calculate_column_range(num_columns, invalid_columns) {
-        const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - this._container_size.width);
-        const percent_left = Math.max(0, Math.ceil(this.scrollLeft)) / total_scroll_width;
-        const max_scroll_column = this._max_scroll_column(num_columns);
+    _calculate_column_range(num_columns) {
         if (this._virtual_mode === "none" || this._virtual_mode === "vertical") {
             return {start_col: 0, end_col: Infinity};
         } else {
-            let start_col = max_scroll_column * percent_left;
-            const vis_cols = (!invalid_columns && this.table_model.num_columns()) || Math.min(num_columns, Math.ceil(this._container_size.width / 60));
+            const start_col = this._calc_start_column();
+            const vis_cols = this.table_model.num_columns() || Math.min(num_columns, Math.ceil(this._container_size.width / 60));
             let end_col = start_col + vis_cols + 1;
             return {start_col, end_col};
         }
@@ -275,6 +286,20 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         return {invalid_column, invalid_row};
     }
 
+    _calc_scrollable_column_width(num_columns) {
+        let scroll_index_offset = this._view_cache.config.row_pivots.length;
+        const max_scroll_column = this._max_scroll_column(num_columns);
+        let cidx = scroll_index_offset,
+            virtual_width = 0;
+
+        while (cidx < max_scroll_column + scroll_index_offset) {
+            virtual_width += this._column_sizes.indices[cidx] || 60;
+            cidx++;
+        }
+
+        return virtual_width;
+    }
+
     /**
      * Updates the `virtual_panel` width based on view state.
      *
@@ -288,15 +313,8 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             if (this._virtual_mode === "vertical" || this._virtual_mode === "none") {
                 this._virtual_panel.style.width = this._column_sizes.indices.reduce((x, y) => x + y, 0) + "px";
             } else {
-                let scroll_index_offset = this._view_cache.config.row_pivots.length;
-                const max_scroll_column = this._max_scroll_column(num_columns);
-                let cidx = scroll_index_offset,
-                    virtual_width = 0;
-                while (cidx < max_scroll_column + scroll_index_offset) {
-                    virtual_width += this._column_sizes.indices[cidx] || 60;
-                    cidx++;
-                }
-                const panel_width = this._container_size.width + virtual_width;
+                const virtual_width = this._calc_scrollable_column_width(num_columns);
+                const panel_width = this._container_size.width + virtual_width + 1;
                 this._virtual_panel.style.width = panel_width + "px";
             }
         }
@@ -330,31 +348,16 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * the implementor to fine tune the individual render frames based on the
      * interaction and previous render state.
      *
-     * `reset_scroll_position` will not prevent the viewport from moving as
-     * `draw()` may change the dimensions of the virtual_panel (and thus,
-     * absolute scroll offset).  This calls `reset_scroll`, which will
-     * trigger `_on_scroll` and ultimately `draw()` again;  however, this call
-     * to `draw()` will be for the same viewport and will not actually cause
-     * a render.
-     *
      * @public
      * @memberof RegularVirtualTableViewModel
      * @param {DrawOptions} [options]
      * @param {boolean} [options.invalid_viewport=true]
      * @param {boolean} [options.preserve_width=false]
-     * @param {boolean} [options.reset_scroll_position=false]
-     * @param {boolean} [options.swap=false]
      */
     @throttlePromise
     async draw(options = {}) {
         const __debug_start_time__ = DEBUG && performance.now();
-        const {invalid_viewport = true, preserve_width = false, reset_scroll_position = false, invalid_columns = false} = options;
-
-        if (reset_scroll_position) {
-            this.reset_scroll();
-        }
-
-        this._invalid_schema = invalid_columns || this._invalid_schema;
+        const {invalid_viewport = true, preserve_width = false} = options;
         const {num_columns, num_rows} = await this._view_cache.view(0, 0, 0, 0);
         this._container_size = {
             width: this._virtual_mode === "none" || this._virtual_mode === "vertical" ? Infinity : this._table_clip.clientWidth,
@@ -366,7 +369,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             this._update_virtual_panel_width(invalid_viewport, num_columns);
         }
 
-        const viewport = this._calculate_viewport(num_rows, num_columns, reset_scroll_position, invalid_columns);
+        const viewport = this._calculate_viewport(num_rows, num_columns);
         const {invalid_row, invalid_column} = this._validate_viewport(viewport);
         if (this._invalid_schema || invalid_row || invalid_column || invalid_viewport) {
             let autosize_cells = [];
@@ -409,10 +412,10 @@ export class RegularVirtualTableViewModel extends HTMLElement {
         const y_offset = this._column_sizes.row_height * (viewport.start_row % 1) || 0;
         const x_offset = this._column_sizes.indices[(this.table_model._row_headers_length || 0) + Math.floor(viewport.start_col)] * (viewport.start_col % 1) || 0;
         let style = this._sub_cell_style.sheet.cssRules[0].style;
-        style.setProperty(`--regular-table--transform-x`, `-${x_offset}px`);
-        style.setProperty(`--regular-table--transform-y`, `-${y_offset}px`);
         style.setProperty(`--regular-table--clip-x`, `${x_offset}px`);
         style.setProperty(`--regular-table--clip-y`, `${y_offset}px`);
+        style.setProperty(`--regular-table--transform-x`, `-${x_offset}px`);
+        style.setProperty(`--regular-table--transform-y`, `-${y_offset}px`);
     }
 }
 
@@ -424,6 +427,4 @@ export class RegularVirtualTableViewModel extends HTMLElement {
  * @type {object}
  * @property {boolean} [invalid_viewport]
  * @property {boolean} [preserve_width]
- * @property {boolean} [reset_scroll_position]
- * @property {boolean} [swap]
  */

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -195,7 +195,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      */
     _calculate_column_range(num_columns, invalid_columns) {
         const total_scroll_width = Math.max(1, this._virtual_panel.offsetWidth - this._container_size.width);
-        const percent_left = Math.max(0, this.scrollLeft) / total_scroll_width;
+        const percent_left = Math.max(0, Math.ceil(this.scrollLeft)) / total_scroll_width;
         const max_scroll_column = this._max_scroll_column(num_columns);
         if (this._virtual_mode === "none" || this._virtual_mode === "vertical") {
             return {start_col: 0, end_col: Infinity};

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -66,10 +66,11 @@ export class RegularTableViewModel {
             }
             this._column_sizes.row_height = this._column_sizes.row_height || row_height_cell.offsetHeight;
             this._column_sizes.indices[metadata.size_key] = offsetWidth;
-            const is_override = this._column_sizes.override.hasOwnProperty(metadata.size_key);
+            const is_override = this._column_sizes.override[metadata.size_key] !== undefined;
             if (offsetWidth && !is_override) {
                 this._column_sizes.auto[metadata.size_key] = offsetWidth;
             }
+
             if (cell.style.minWidth === "0px") {
                 cell.style.minWidth = `${offsetWidth}px`;
             }

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -18,6 +18,12 @@ import {ViewModel} from "./view_model";
  * @class RegularHeaderViewModel
  */
 export class RegularHeaderViewModel extends ViewModel {
+    constructor(...args) {
+        super(...args);
+        this._group_header_cache = [];
+        this._offset_cache = [];
+    }
+
     _draw_group_th(offset_cache, d, column) {
         const th = this._get_cell("TH", d, offset_cache[d] || 0);
         offset_cache[d] += 1;
@@ -77,9 +83,6 @@ export class RegularHeaderViewModel extends ViewModel {
     get_column_header(cidx) {
         return this._get_cell("TH", this.num_rows() - 1, cidx);
     }
-
-    _group_header_cache = [];
-    _offset_cache = [];
 
     draw(alias, parts, colspan, x, size_key, x0, _virtual_x) {
         const header_levels = parts?.length; //config.column_pivots.length + 1;

--- a/test/examples/spreadsheet.test.js
+++ b/test/examples/spreadsheet.test.js
@@ -126,16 +126,16 @@ describe("spreadsheet.html", () => {
             keydownDownArrow(table, 5);
             await sayHello(table);
 
-            const tds = await page.$$("regular-table tbody tr:nth-of-type(3) td");
+            const tds = await page.$$("regular-table tbody tr:nth-of-type(4) td");
             const cells = [];
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
             expect(cells).toEqual(["Hello, World!", "", "", "", "", "", ""]);
 
-            const ths = await page.$$("regular-table tbody tr:nth-of-type(3) th");
+            const ths = await page.$$("regular-table tbody tr:nth-of-type(4) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);
-            expect(th).toEqual("5");
+            expect(th).toEqual("6");
         });
 
         test("scrolls down and back up", async () => {
@@ -159,7 +159,7 @@ describe("spreadsheet.html", () => {
         test("scrolls right and back left", async () => {
             const table = await page.$("regular-table");
             keydownRightArrow(table, 10);
-            keydownLeftArrow(table, 5);
+            keydownLeftArrow(table, 7);
             await sayHello(table);
 
             const tds = await page.$$("regular-table tbody tr:nth-of-type(1) td");
@@ -167,7 +167,7 @@ describe("spreadsheet.html", () => {
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(cells).toEqual(["", "", "", "", "", "Hello, World!"]);
+            expect(cells).toEqual(["", "", "", "Hello, World!"]);
 
             const ths = await page.$$("regular-table tbody tr:nth-of-type(1) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);
@@ -179,16 +179,16 @@ describe("spreadsheet.html", () => {
             keypressReturn(table, 5);
             await sayHello(table);
 
-            const tds = await page.$$("regular-table tbody tr:nth-of-type(3) td");
+            const tds = await page.$$("regular-table tbody tr:nth-of-type(4) td");
             const cells = [];
             for (const td of tds) {
                 cells.push(await page.evaluate((td) => td.innerHTML, td));
             }
             expect(cells).toEqual(["Hello, World!", "", "", "", "", "", ""]);
 
-            const ths = await page.$$("regular-table tbody tr:nth-of-type(3) th");
+            const ths = await page.$$("regular-table tbody tr:nth-of-type(4) th");
             const th = await page.evaluate((th) => th.innerHTML, ths[0]);
-            expect(th).toEqual("5");
+            expect(th).toEqual("6");
         });
     });
 
@@ -272,13 +272,13 @@ describe("spreadsheet.html", () => {
             for (const td of tr2) {
                 tds2.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(tds2).toEqual(["1", "", "", "", "", "", ""]);
+            expect(tds2).toEqual(["1", "", "", ""]);
             const tr3 = await page.$$("regular-table tbody tr:nth-of-type(4) td");
             const tds3 = [];
             for (const td of tr3) {
                 tds3.push(await page.evaluate((td) => td.innerHTML, td));
             }
-            expect(tds3).toEqual(["2", "3", "", "", "", "", ""]);
+            expect(tds3).toEqual(["2", "3", "", ""]);
         });
 
         describe("on scroll", () => {
@@ -296,13 +296,13 @@ describe("spreadsheet.html", () => {
                 for (const td of tr1) {
                     tds1.push(await page.evaluate((td) => td.innerHTML, td));
                 }
-                expect(tds1).toEqual(["1", "", "", "", "", "", ""]);
+                expect(tds1).toEqual(["1", "", "", ""]);
                 const tr2 = await page.$$("regular-table tbody tr:nth-of-type(3) td");
                 const tds2 = [];
                 for (const td of tr2) {
                     tds2.push(await page.evaluate((td) => td.innerHTML, td));
                 }
-                expect(tds2).toEqual(["2", "3", "", "", "", "", ""]);
+                expect(tds2).toEqual(["2", "3", "", ""]);
             });
         });
     });

--- a/test/features/scrollTo.test.js
+++ b/test/features/scrollTo.test.js
@@ -36,7 +36,7 @@ describe("scrollToCell", () => {
             const meta = await page.evaluate((table) => {
                 return table.getMeta(document.querySelector("td"));
             }, table);
-            expect(meta.x).toEqual(2);
+            expect(meta.x).toEqual(1);
         });
 
         test("for scrollToCell position {x: 1000, y: 0}", async () => {
@@ -73,7 +73,7 @@ describe("scrollToCell", () => {
             }, table);
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent), first_tr);
-            expect(cell_values).toEqual(["Group 640", "Row 647", "858"]);
+            expect(cell_values).toEqual(["Group 640", "Row 647", "857"]);
         });
     });
 });


### PR DESCRIPTION
Previously, horizontal scrolling was calculated by evenly distributing the available `scrollWidth` among the viewable columns.  This worked fine and arguably made cell-aligned-scrolling more pleasant, but caused a perceived scroll position drift when the `regular-table` dimensions were changed as the `scrollWidth` / `offsetWidth` ratio changed.  This PR makes this behave linear with the column sizes, so e.g. scrolling through a 200px column will take twice as many pixels as a 100px column.  This scrolling model works better (arguably) with sub-cell scrolling introduced in `0.5.0`, and more importantly does not cause position drift.