### PR TITLE
Fix a miscalculation in row_header offsets

### DIFF
--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -192,7 +192,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
             offset_width += new_val !== undefined ? new_val : 60;
         }
 
-        start_col += diff / (this._column_sizes.indices[start_col - 1] || 60);
+        start_col += diff / (this._column_sizes.indices[start_col + scroll_index_offset - 1] || 60);
         return Math.max(0, start_col - 1);
     }
 


### PR DESCRIPTION
Fixes a miscalculation in width which caused some jitter when width is slightly larger than viewport.